### PR TITLE
Fix failing exception handling in JWT validation

### DIFF
--- a/amplify-assistants/common/validate.py
+++ b/amplify-assistants/common/validate.py
@@ -467,12 +467,9 @@ def get_claims(event, context):
         except jwt.ExpiredSignatureError:
             print("Token has expired.")
             raise Unauthorized("Token has expired.")
-        except jwt.InvalidAudienceError:
-            print("Invalid audience.")
-            raise Unauthorized("Invalid audience.")
-        except jwt.InvalidIssuerError:
-            print("Invalid issuer.")
-            raise Unauthorized("Invalid issuer.")
+        except jwt.JWTClaimsError as e:
+            print(f"JWT Claims Error: {e}")
+            raise Unauthorized(str(e)) 
         except Exception as e:
             print(f"Error during token validation: {e}")
             raise Unauthorized(f"Error during token validation: {e}")

--- a/amplify-lambda/common/validate.py
+++ b/amplify-lambda/common/validate.py
@@ -732,12 +732,9 @@ def get_claims(event, context):
         except jwt.ExpiredSignatureError:
             print("Token has expired.")
             raise Unauthorized("Token has expired.")
-        except jwt.InvalidAudienceError:
-            print("Invalid audience.")
-            raise Unauthorized("Invalid audience.")
-        except jwt.InvalidIssuerError:
-            print("Invalid issuer.")
-            raise Unauthorized("Invalid issuer.")
+        except jwt.JWTClaimsError as e:
+            print(f"JWT Claims Error: {e}")
+            raise Unauthorized(str(e)) 
         except Exception as e:
             print(f"Error during token validation: {e}")
             raise Unauthorized(f"Error during token validation: {e}")


### PR DESCRIPTION
InvalidAudienceError and InvalidIssuerError do not exist in Jose, so when we encounter an exception validating audience or issuer, we fail with another one such as "AttributeError: module 'jose.jwt' has no attribute 'InvalidAudienceError'"