### PR TITLE
object-access/serverless.yml missing a Environment Variable and Lambda Permission

### DIFF
--- a/object-access/serverless.yml
+++ b/object-access/serverless.yml
@@ -73,6 +73,7 @@ provider:
     API_BASE_URL: https://${self:custom.stageVars.CUSTOM_API_DOMAIN}  
     HASH_FILES_DYNAMO_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-hash-files
     IDP_PREFIX: ${self:custom.stageVars.IDP_PREFIX}
+    AMPLIFY_ADMIN_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-admin-${sls:stage}-admin-configs
   iam:
     role:
       managedPolicies:
@@ -301,6 +302,7 @@ resources:
                 - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-${sls:stage}-amplify-groups"
                 - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-${sls:stage}-amplify-group-logs"
                 - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-hash-files"
+                - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/amplify-${self:custom.stageVars.DEP_NAME}-admin-${sls:stage}-admin-configs"
             - Effect: Allow
               Action:
                 - cognito-idp:ListUsers


### PR DESCRIPTION
Inside cognito_users_sync.py was experiencing KeyError on line 13

```
    admin_table = dynamodb.Table(os.environ['AMPLIFY_ADMIN_DYNAMODB_TABLE'])
```
Noticed that the lambda was missing environment variable for AMPLIFY_ADMIN_DYNAMODB_TABLE and the appropriate permissions to access. 

I added both to the serverless.yml so will be there on future deployments