### PR TITLE
Refactor access type management and update group permissions logic

### DIFF
--- a/amplify-lambda-js/router.js
+++ b/amplify-lambda-js/router.js
@@ -208,7 +208,6 @@ export const routeRequest = async (params, returnResponse, responseStream) => {
                 responseStream);
             chatSegment.close();
             
-            await deleteRequestState(params.user, requestId);
 
             if(doTrace) {
                 trace(requestId, ["response"], {stream: responseStream.trace})


### PR DESCRIPTION
- Updated the `create_api_key_for_group` function to include additional access types: 'chat', 'dual_embedding', 'embedding', and 'file_upload'.
- Modified the `update_group_ds_perms` function to accept an `access_token` parameter and adjusted the embedding completion check accordingly.
- Ensured that the `update_assistants` function passes the `access_token` when updating data source permissions.
- Remove delete state for chat js to fix agent loop bug