### PR TITLE
Integrate Bedrock Guardrails in model invocation

### DIFF
--- a/amplify-lambda-js/bedrock/bedrock.js
+++ b/amplify-lambda-js/bedrock/bedrock.js
@@ -52,7 +52,13 @@ export const chatBedrock = async (chatBody, writable) => {
                         messages: sanitizedMessages,
                         inferenceConfig: inferenceConfigs,
                         }
-
+        const guardrailArn = process.env.BEDROCK_GUARDRAIL_ARN;
+        if (guardrailArn) {
+            input.guardrailConfig = {
+                "guardrailIdentifier": guardrailArn,
+                "guardrailVersion": 'DRAFT'
+            };
+        }
         if (currentModel.supportsSystemPrompts) {
             input.system = systemPrompts;
         } else {

--- a/amplify-lambda-js/serverless.yml
+++ b/amplify-lambda-js/serverless.yml
@@ -74,6 +74,7 @@ provider:
     IDP_PREFIX: ${self:custom.stageVars.IDP_PREFIX}
     ADMIN_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-admin-${sls:stage}-admin-configs
     DEP_REGION: ${self:custom.stageVars.DEP_REGION} 
+    BEDROCK_GUARDRAIL_ARN: ${self:custom.stageVars.BEDROCK_GUARDRAIL_ARN}
     AGENT_ENDPOINT: ${self:custom.stageVars.AGENT_ENDPOINT}
     AGENT_STATE_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-agent-loop-${sls:stage}-agent-state
     S3_RAG_INPUT_BUCKET_NAME: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-rag-input
@@ -191,6 +192,7 @@ resources:
                 - sqs:GetQueueAttributes
                 - bedrock:InvokeModelWithResponseStream
                 - bedrock:InvokeModel
+                - bedrock:ApplyGuardrail
               Resource:
                 - '${self:provider.environment.LLM_ENDPOINTS_SECRETS_NAME_ARN}'
                 - "arn:aws:secretsmanager:${aws:region}:*:secret:${self:provider.environment.SECRETS_ARN_NAME}*"
@@ -367,8 +369,10 @@ resources:
               Action:
                 - bedrock:InvokeModelWithResponseStream
                 - bedrock:InvokeModel
+                - bedrock:ApplyGuardrail
               Resource:
                 - 'arn:aws:bedrock:*::foundation-model/*'
+                - '${self:provider.environment.BEDROCK_GUARDRAIL_ARN}'
                 - !Sub arn:aws:bedrock:*:${AWS::AccountId}:inference-profile/*
   Outputs:
     BedrockIAMPolicyArn:

--- a/dev-var.yml-example
+++ b/dev-var.yml-example
@@ -23,6 +23,7 @@ KEYWORD_MODEL_NAME: "gpt-35-turbo"
 CHANGE_SET_BOOLEAN: false #BOOLEAN FOR WHETHER CHANGE SETS ARE REQUIRED FOR DEPLOYMENTS
 CHAT_ENDPOINT: "" #function url for lambda
 AGENT_ENDPOINT: "" #leave blank for future release
+BEDROCK_GUARDRAIL_ARN: "" # ARN of Bedrock Guardrail from IAC output
 
 
 


### PR DESCRIPTION
This PR updates the backend services to actively use AWS Bedrock Guardrails. This ensures all AI model interactions are filtered through defined safety and content policies, improving platform compliance and security.

### **Prerequisites & Configuration**

To enable this feature, a Bedrock Guardrail must exist in the target AWS account and region.

A new environment variable, `BEDROCK_GUARDRAIL_ARN`, has been added to the `dev-var.yml-example` file. This variable must be added to the relevant `{env}-var.yml` configuration file, with its value set to the full ARN of the guardrail to be used.

### **Implementation Details**

- Configuration: The service now reads the `BEDROCK_GUARDRAIL_ARN` from the `{env}-var.yml` file. This ARN is then used to derive the Guardrail ID and Version for the API call.

- IAM Policy: The Lambda's execution role has been updated with the `bedrock:ApplyGuardrail` permission, allowing the function to enforce the specified guardrail.

### **Deployment for Existing Environments**

For any existing environment, after setting the `BEDROCK_GUARDRAIL_ARN` variable in the configuration file, the `amplify-lambda-js` service must be re-deployed for the changes to take effect.
