### PR TITLE
Support OpenAI API Key use in js for models with providers set as OpenAI

### DIFF
--- a/amplify-lambda-js/azure/openai.js
+++ b/amplify-lambda-js/azure/openai.js
@@ -80,16 +80,12 @@ export const chat = async (endpointProvider, chatBody, writable) => {
     }
     
 
-    if(tools){
-        data.tools = tools;
-    }
-    if(tool_choice){
-        data.tool_choice = tool_choice;
-    }
+    if (tools) data.tools = tools;
+    if (tool_choice) data.tool_choice = tool_choice;
 
     if (data.imageSources) delete data.imageSources;
     
-    const config = await endpointProvider(modelId);
+    const config = await endpointProvider(modelId, model.provider);
 
     const url = config.url;
     const isOpenAiEndpoint = isOpenAIEndpoint(url);

--- a/amplify-lambda-js/common/secrets.js
+++ b/amplify-lambda-js/common/secrets.js
@@ -67,6 +67,22 @@ const secret_data = await getSecret(secret_name);
 const parsed_secret = JSON.parse(secret_data);
 
 // The get_llm_config function converted to JavaScript
-export const getLLMConfig = async (model_name) => {
+export const getLLMConfig = async (model_name, model_provider) => {
+    if (model_provider === "OpenAI") {
+        const url = "https://api.openai.com/v1/chat/completions";
+        const key = await getOpenAIApiKey();
+        return {url, key};
+    }
     return getEndpointData(parsed_secret, model_name);
 };
+
+const getOpenAIApiKey = async () => {
+    const secret = await getSecret(process.env.SECRETS_ARN_NAME);
+    try {
+        const apiKey = JSON.parse(secret).OPENAI_API_KEY;
+        return apiKey;
+    } catch (error) {
+        logger.error("Error getting OpenAI API key:", error);
+        return null;
+    }
+}


### PR DESCRIPTION
- Updated `getLLMConfig` to accept `model_provider` and return OpenAI API details when applicable.
- Added `getOpenAIApiKey` function to securely retrieve the OpenAI API key from secrets.
- Simplified conditional assignments in the `chat` function for better readability.
- Modified endpoint provider call in `chat` to include the model provider.