### PR TITLE
Bug fix - Update required fields in register_ops_schema.py

### DIFF
--- a/amplify-lambda-ops/schemata/register_ops_schema.py
+++ b/amplify-lambda-ops/schemata/register_ops_schema.py
@@ -43,7 +43,7 @@ register_ops_schema = {
                         "items": {"type": "string"},
                     },
                 },
-                "required": ["id", "method", "url", "name", "params"],
+                "required": ["id", "method", "url", "name"],
                 "additionalProperties": True,
             },
         },


### PR DESCRIPTION
- Removed "params" from the required fields in the operation schema to streamline the registration process and improve validation.