### PR TITLE
Fix error handling in reset_embedding_status_to_starting function by …

### DIFF
--- a/embedding/embedding-dual-retrieval.py
+++ b/embedding/embedding-dual-retrieval.py
@@ -703,4 +703,4 @@ def reset_embedding_status_to_starting(src_id):
             
     except Exception as e:
         logging.error(f"[RESET_STATUS] ❌ Failed to reset embedding status for {src_id}: {str(e)}")
-        # Don't raise the exception - let the manual queue continue even if reset fails
+        raise e


### PR DESCRIPTION
…raising exceptions instead of logging them. This change ensures that failures in resetting the embedding status are properly propagated for better debugging.