### PR TITLE
Bug fix - TokenV1 key generation to use SHAKE256

### DIFF
--- a/amplify-lambda-js/common/api_utils.js
+++ b/amplify-lambda-js/common/api_utils.js
@@ -65,9 +65,7 @@ class TokenV1 extends Token {
      * @returns {string} The hashed key as a hex string.
      */
     static _keyGenerator(rawKey, salt = "") {
-        // Using SHAKE256 equivalent - Node.js doesn't have SHAKE256, so using SHA3-256 instead
-        // which provides similar security properties
-        const hash = crypto.createHash('sha3-256');
+        const hash = crypto.createHash('shake256', { outputLength: 64 });
         hash.update(rawKey + salt);
         return hash.digest('hex');
     }


### PR DESCRIPTION
- Updated the _keyGenerator method in TokenV1 to utilize SHAKE256 for hashing instead of SHA3-256, enhancing security properties of the key generation process.