### PR TITLE
Update build-fat.sh to require manual repository URI input

### DIFF
--- a/amplify-agent-loop-lambda/build-fat.sh
+++ b/amplify-agent-loop-lambda/build-fat.sh
@@ -3,8 +3,8 @@ set -e
 
 REGION="us-east-1"
 STAGE="${1:-dev}"
-DEV_REPOSITORY_URI="654654422653.dkr.ecr.us-east-1.amazonaws.com/dev-amplifygenai-repo"
-PROD_REPOSITORY_URI="514391678313.dkr.ecr.us-east-1.amazonaws.com/prod-amplifygenai-repo"
+DEV_REPOSITORY_URI="" # ADD YOUR DEV REPO URI
+PROD_REPOSITORY_URI="" # ADD YOUR PROD REPO URI
 
 # Set repository URI based on stage
 if [ "$STAGE" = "prod" ]; then


### PR DESCRIPTION
- Modified the DEV_REPOSITORY_URI and PROD_REPOSITORY_URI variables to prompt users to add their respective repository URIs manually.
- This change enhances clarity for developers setting up the environment by indicating that these values need to be configured before use.