### PR TITLE
Bug Fix - Standalone Ast  Data Sources Permissions bug

### DIFF
--- a/amplify-assistants/service/core.py
+++ b/amplify-assistants/service/core.py
@@ -898,8 +898,13 @@ def share_assistant_with(
 
     if not assistant_entry:
         return {"success": False, "message": "Assistant not found"}
+    
+    from service.drive_datasources import extract_drive_datasources
+    drive_data_sources = extract_drive_datasources(assistant_entry.get("data", {}).get("integrationDriveData", {}))
+    # if (drive_data_sources):
+    #     print(f"Drive data sources: {drive_data_sources}")
 
-    data_sources = get_data_source_keys(assistant_entry["dataSources"])
+    data_sources = get_data_source_keys(assistant_entry["dataSources"] + drive_data_sources)
     # print("DS: ", data_sources)
 
     if not can_access_objects(

--- a/amplify-lambda-js/serverless.yml
+++ b/amplify-lambda-js/serverless.yml
@@ -57,6 +57,7 @@ provider:
     ASSISTANT_LOGS_BUCKET_NAME: amplify-${self:custom.stageVars.DEP_NAME}-${sls:stage}-assistant-chat-logs
     ASSISTANTS_ALIASES_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-assistants-${sls:stage}-assistant-aliases
     ASSISTANTS_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-assistants-${sls:stage}-assistants
+    ASSISTANT_LOOKUP_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-assistants-${sls:stage}-assistant-lookup
     CHAT_USAGE_DYNAMO_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-chat-usage
     REQUEST_STATE_DYNAMO_TABLE: ${self:service}-${sls:stage}-request-state
     TRACE_BUCKET_NAME: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-chat-traces
@@ -219,6 +220,8 @@ resources:
                 - "arn:aws:s3:::${self:provider.environment.TRACE_BUCKET_NAME}/*"
                 - "arn:aws:s3:::${self:provider.environment.ASSISTANT_TASK_RESULTS_BUCKET_NAME}/*"
                 - "arn:aws:s3:::${self:provider.environment.ASSISTANT_LOGS_BUCKET_NAME}/*"
+                - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.ASSISTANT_LOOKUP_DYNAMODB_TABLE}"
+                - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.ASSISTANT_LOOKUP_DYNAMODB_TABLE}/index/*"
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.GROUPS_DYNAMO_TABLE}"
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.GROUPS_DYNAMO_TABLE}/*"
                 - "arn:aws:s3:::${self:provider.environment.S3_GROUP_ASSISTANT_CONVERSATIONS_BUCKET_NAME}"

--- a/embedding/schemata/dual_retrieval_schema.py
+++ b/embedding/schemata/dual_retrieval_schema.py
@@ -14,6 +14,11 @@ dual_retrieval_schema = {
             "description": "A dict of group data sources to search for related documents. Group is the key, list of globals is the value.",
             "additionalProperties": {"type": "array", "items": {"type": "string"}},
         },
+        "astDataSources": {
+            "type": "object",
+            "description": "A dict of ast data sources to search for related documents. Ast is the key, list of globals is the value.",
+            "additionalProperties": {"type": "array", "items": {"type": "string"}},
+        },
         "limit": {
             "type": "integer",
             "description": "The maximum number of documents to return.",

--- a/embedding/serverless.yml
+++ b/embedding/serverless.yml
@@ -83,6 +83,7 @@ provider:
     COST_CALCULATIONS_DYNAMO_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-cost-calculations
     S3_FILE_TEXT_BUCKET_NAME: amplify-${self:custom.stageVars.DEP_NAME}-lambda-${sls:stage}-file-text
     GROUPS_DYNAMO_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-object-access-${sls:stage}-amplify-groups
+    ASSISTANT_LOOKUP_DYNAMODB_TABLE: amplify-${self:custom.stageVars.DEP_NAME}-assistants-${sls:stage}-assistant-lookup
     EMBEDDING_IAM_POLICY_NAME: ${self:service}-${sls:stage}-iam-policy
     API_BASE_URL: https://${self:custom.stageVars.CUSTOM_API_DOMAIN}
 
@@ -322,6 +323,8 @@ resources:
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.MODEL_RATE_TABLE}/*"
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.AMPLIFY_ADMIN_DYNAMODB_TABLE}"
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.AMPLIFY_ADMIN_DYNAMODB_TABLE}*"
+                - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.ASSISTANT_LOOKUP_DYNAMODB_TABLE}"
+                - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.ASSISTANT_LOOKUP_DYNAMODB_TABLE}/index/*"
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:service}-${sls:stage}-embedding-progress"
                 - "arn:aws:sqs:${aws:region}:*:amplify-${self:custom.stageVars.DEP_NAME}-embedding-${sls:stage}-embedding-chunks-index-queue"
                 - "arn:aws:sqs:${aws:region}:*:amplify-${self:custom.stageVars.DEP_NAME}-embedding-${sls:stage}-embedding-chunks-index-dlq"


### PR DESCRIPTION
- Added functionality to extract and integrate drive data sources into the assistant sharing process in `core.py`.
- Updated `add_assistant_path` in `standalone_ast_path.py` to handle drive data sources and permissions more effectively.
- Introduced new methods for classifying access to assistant data sources in `embedding/embedding-dual-retrieval.py`.
- Enhanced the schema in `dual_retrieval_schema.py` to include `astDataSources` for improved data handling.
- Updated serverless configurations to include the new `ASSISTANT_LOOKUP_DYNAMODB_TABLE` for better data access management.