### PR TITLE
docs: add Serverless services overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,43 @@
 
 This repository serves as a Mono Repo for managing all Amplify Lambda functions. It is part of a larger deployment for Amplify GenAI which can be found at https://github.com/gaiin-platform.
 
+All services are orchestrated via [Serverless Compose](https://www.serverless.com/framework/docs/guides/compose) (`serverless-compose.yml`) and share a single API Gateway.
+
+## Serverless Services
+
+The backend is composed of the following services, each deployed as an independent Serverless Framework stack. Cross-service references (DynamoDB table names, SQS queue URLs, etc.) are shared through AWS SSM Parameter Store and CloudFormation exports.
+
+| # | Service Directory | Service Name | Runtime | Description |
+|---|---|---|---|---|
+| 1 | `amplify-lambda` | amplify-lambda | Python 3.11 | **Core Platform** — API Gateway custom domain, file management, conversations, sharing, document conversion, user accounts, tags, and user data routing. Creates foundational S3 buckets (file-text, image-input, rag-input, rag-chunks, consolidation) and DynamoDB tables (accounts, files, chat-usage, hash-files, cost-calculations, user-tags, user-storage, env-vars-tracking, conversation-metadata, db-connections). |
+| 2 | `amplify-lambda-js` | amplify-js | Node.js 22.x | **Chat & Streaming** — LLM chat streaming via API Gateway and Lambda Function URLs, Bedrock model invocation, billing reset (daily cron), month-to-date cost reporting, billing group costs, user cost history, and conversation analysis (SQS-driven). Creates cost-calculation tables, request-state table, datasource-registry table, and chat-traces S3 bucket. |
+| 3 | `amplify-assistants` | amplify-assistants | Python 3.11 | **Assistants Management** — CRUD operations for AI assistants, assistant sharing, thread/run management, code interpreter sessions, assistant aliases, lookup tables, and group assistant conversations. |
+| 4 | `amplify-lambda-admin` | amplify-admin | Python 3.11 | **Admin Panel** — Admin configuration management, feature flags, user app configs, PowerPoint template management, admin authentication, Amplify group membership, and critical error tracking (DynamoDB Streams → SNS notifications, SQS processing with DLQ). Runs a scheduled sync of assistant admins every 3 minutes. |
+| 5 | `amplify-lambda-api` | amplify-api | Python 3.11 | **API Key Management** — API key creation, rotation, deactivation, per-assistant key retrieval, system ID lookup, API documentation templates, and tools/ops registration. |
+| 6 | `amplify-lambda-artifacts` | amplify-artifacts | Python 3.11 | **User Artifacts** — Save, retrieve, delete, and share user-generated artifacts (code, documents, etc.) stored in DynamoDB. |
+| 7 | `amplify-lambda-ops` | amplify-lambda-ops | Python 3.11 | **Operations Registry** — Register, retrieve, update, and delete custom operations/tools. Stores ops in a DynamoDB table keyed by user and tag. |
+| 8 | `amplify-lambda-assistants-api` | amplify-assistants-api | Python 3.11 | **Assistants API & Integrations Hub** — OAuth integration management (start auth, callbacks, token refresh, secret registration), third-party drive file listing/upload/download, custom automation execution, job result management, and MCP server endpoints. Creates OAuth state, user-oauth-integrations, op-log, and job-status tables. |
+| 9 | `amplify-lambda-assistants-api-google` | amplify-google | Python 3.11 | **Google Integration** — Google Workspace integration router, Google-specific OAuth flows, and admin config ops trigger (via DynamoDB Streams on the admin table). |
+| 10 | `amplify-lambda-assistants-api-office365` | amplify-office365 | Python 3.11 | **Microsoft 365 Integration** — Microsoft/Office 365 integration router, Microsoft-specific OAuth flows, and admin config ops trigger (via DynamoDB Streams on the admin table). |
+| 11 | `chat-billing` | amplify-chat-billing | Python 3.11 | **Billing & Model Management** — Available models retrieval, supported/default model management, model rate tables, and additional charges tracking (code interpreter, embeddings, infrastructure costs). |
+| 12 | `object-access` | amplify-object-access | Python 3.11 | **Access Control & Groups** — Cognito user directory, Amplify group management (create, update members/types/permissions, delete), object-level permission management, user validation, access simulation, and per-function IAM roles. Creates API keys, cognito-users, object-access, amplify-groups, and group-logs tables. |
+| 13 | `data-disclosure` | amplify-data-disclosure | Python 3.11 | **Data Disclosure** — Data disclosure versioning, user acceptance/denial tracking, disclosure document upload (presigned URLs), and latest disclosure retrieval. |
+| 14 | `embedding` | amplify-embedding | Python 3.11 | **RAG Embedding Pipeline** — Dual-retrieval embedding generation, embedding chunk processing (SQS → Aurora Serverless PostgreSQL with pgvector), embedding deletion, status tracking, DLQ reprocessing, and table creation. Provisions an Aurora Serverless v2 PostgreSQL cluster with KMS encryption for vector storage. |
+| 15 | `amplify-agent-loop-lambda` | amplify-agent-loop | Python 3.11 | **Agent Execution Loop** — Agent routing (REST proxy), asynchronous agent event processing (SQS), scheduled tasks execution (every 3 minutes), built-in tools endpoint, and workflow template management. Creates agent-state, agent-event-templates, email-settings, scheduled-tasks, and workflow-registry tables. |
+
+### Service Dependency Graph
+
+Services share resources through SSM Parameter Store. Below are the key dependency relationships:
+
+- **amplify-lambda** (Core) — foundational service; exports table names and bucket names consumed by most other services.
+- **amplify-lambda-admin** — exports the admin config table stream ARN (consumed by Google & Office365 integration services) and the critical errors SQS queue/SNS topic (consumed by all services for error reporting).
+- **amplify-lambda-js** — exports cost-calculations and request-state table names; depends on amplify-lambda, amplify-admin, object-access, and chat-billing.
+- **object-access** — exports API keys, cognito-users, assistant-groups, and object-access table names consumed by nearly all services.
+- **chat-billing** — exports model-rate and additional-charges table names consumed by multiple services.
+- **amplify-assistants** — exports assistant table names consumed by amplify-lambda-js, embedding, and agent-loop.
+- **amplify-lambda-ops** — exports the ops table name consumed by chat-billing, embedding, agent-loop, and integration services.
+- **embedding** — exports the embedding chunks index queue; consumes from amplify-lambda's RAG chunk document queue.
+
 ## Setup Requirements
 
 Initial setup requires the creation of a `/var` directory at the root level of the repository. The environment-specific variables should be placed in the following files within the `/var` directory:


### PR DESCRIPTION
## Summary

- Reviewed all 15 Serverless services defined in `serverless-compose.yml` and documented each in a comprehensive table
- Added service directory, service name, runtime, and detailed descriptions covering responsibilities, provisioned AWS resources (DynamoDB tables, S3 buckets, SQS queues, Aurora clusters), event sources (HTTP, SQS, DynamoDB Streams, scheduled), and key functions
- Added a "Service Dependency Graph" section explaining how services share state through AWS SSM Parameter Store and CloudFormation exports

Fixes #234

## Changes

Updated `README.md` to include:
1. A note about Serverless Compose orchestration in the Overview section
2. A new **Serverless Services** section with a table documenting all 15 services:
   - `amplify-lambda` (Core Platform)
   - `amplify-lambda-js` (Chat & Streaming)
   - `amplify-assistants` (Assistants Management)
   - `amplify-lambda-admin` (Admin Panel)
   - `amplify-lambda-api` (API Key Management)
   - `amplify-lambda-artifacts` (User Artifacts)
   - `amplify-lambda-ops` (Operations Registry)
   - `amplify-lambda-assistants-api` (Assistants API & Integrations Hub)
   - `amplify-lambda-assistants-api-google` (Google Integration)
   - `amplify-lambda-assistants-api-office365` (Microsoft 365 Integration)
   - `chat-billing` (Billing & Model Management)
   - `object-access` (Access Control & Groups)
   - `data-disclosure` (Data Disclosure)
   - `embedding` (RAG Embedding Pipeline)
   - `amplify-agent-loop-lambda` (Agent Execution Loop)
3. A **Service Dependency Graph** subsection showing key inter-service relationships

## Test Plan

- [x] Verified all 15 services from `serverless-compose.yml` are documented
- [x] Cross-referenced each service description with its `serverless.yml` for accuracy
- [x] Confirmed service names, runtimes, and resource descriptions match actual configurations
- [x] Verified markdown table renders correctly