### PR TITLE
feat(workflow-engine): step output references, repeat/skip controls, …

### DIFF
--- a/amplify-agent-loop-lambda/agent/agents/workflow_agent.py
+++ b/amplify-agent-loop-lambda/agent/agents/workflow_agent.py
@@ -11,6 +11,9 @@ from agent.capabilities.workflow_model import Workflow
 from agent.components.common_goals import (
     CAREFUL_ARGUMENT_SELECTION,
     ALLOW_EARLY_EXIT_AGENT_LOOP,
+    COMPLETE_ALL_REQUIRED_PARAMS,
+    WORKFLOW_STRUCTURED_OUTPUT,
+    FOLLOW_WORKFLOW_STEP_INSTRUCTIONS,
 )
 from agent.components.agent_languages import (
     AgentFunctionCallingActionLanguage,
@@ -181,7 +184,10 @@ def build_clean(
         Goal(
             name="REQUIRED", description="YOU ARE REQUIRED TO CALL A TOOL EVERY TIME!"
         ),
+        FOLLOW_WORKFLOW_STEP_INSTRUCTIONS,
+        COMPLETE_ALL_REQUIRED_PARAMS,
         CAREFUL_ARGUMENT_SELECTION,
+        WORKFLOW_STRUCTURED_OUTPUT,
         ALLOW_EARLY_EXIT_AGENT_LOOP,
         *additional_goals,
     ]

--- a/amplify-agent-loop-lambda/agent/capabilities/workflow_capability.py
+++ b/amplify-agent-loop-lambda/agent/capabilities/workflow_capability.py
@@ -1,4 +1,5 @@
 import json
+import re
 from copy import deepcopy
 from importlib.metadata import metadata
 from typing import List, Optional, Dict, Any
@@ -62,11 +63,12 @@ class ParameterizedActionRegistry(ActionRegistry):
 
     def get_action(self, name: str) -> Optional[Action]:
         original_action = self.wrapped_registry.get_action(name)
-        if not original_action:
-            return None
 
+        # Check if the requested tool matches the current parameterized step
         for param_dict in self.parameterized_args:
             if param_dict.get("tool") == name:
+                if not original_action:
+                    return None
                 args = param_dict.get("args", {})
                 instructions = param_dict.get("instructions")
                 metadata = param_dict
@@ -74,7 +76,28 @@ class ParameterizedActionRegistry(ActionRegistry):
                     original_action, args, instructions, metadata
                 )
 
-        return original_action
+        # Model called a tool that is NOT the current parameterized step.
+        # Since workflows expose only one tool at a time, the model's intent
+        # is always "do the current step" — return the parameterized action
+        # instead so action_def is correct for auto-fill and execution.
+        # Exception: never intercept 'terminate' — that's always a valid call.
+        if self.parameterized_args and name != "terminate":
+            current_tool_name = self.parameterized_args[0].get("tool")
+            current_original = self.wrapped_registry.get_action(current_tool_name)
+            if current_original:
+                param_dict = self.parameterized_args[0]
+                args = param_dict.get("args", {})
+                instructions = param_dict.get("instructions")
+                metadata = param_dict
+                logger.info(
+                    "get_action: model requested '%s' but current step is '%s' — returning current step action_def",
+                    name, current_tool_name,
+                )
+                return self._update_action_parameters(
+                    current_original, args, instructions, metadata
+                )
+
+        return original_action if original_action else None
 
     def get_actions(self) -> List[Action]:
         actions = []
@@ -129,6 +152,10 @@ class WorkflowCapability(Capability):
         self.retry_count = {}  # Track retries for each step
         self.max_retries = 2  # Maximum number of retries per step
         self.terminate_early = False
+        # Step output storage: stepName -> raw result (for {{stepName.field}} references)
+        self.step_outputs: Dict[str, Any] = {}
+        # Repeat counts: step_id -> how many extra times this step has been repeated
+        self.repeat_counts: Dict[str, int] = {}
 
     def init(self, agent, action_context: ActionContext) -> dict:
         self.action_registry = ParameterizedActionRegistry(agent.actions)
@@ -139,6 +166,9 @@ class WorkflowCapability(Capability):
         if self.remaining_steps:
             next_step: Optional[Step] = self.remaining_steps.pop()
             if next_step:
+                # Resolve any {{stepName.field}} references in args/values before checking skip
+                next_step = self._resolve_step_references(next_step)
+
                 step_id = self._construct_step_id(next_step)
                 step_attempted_before = step_id in self.retry_count
                 # skip logic - dont skip failed steps
@@ -171,6 +201,21 @@ class WorkflowCapability(Capability):
     def process_action(
         self, agent, action_context: ActionContext, action_def: Action, action: dict
     ) -> dict:
+        # If the model called the wrong tool, silently rewrite to the expected tool.
+        # The model often gets confused by tool names in conversation history — since
+        # the workflow only exposes one tool at a time, the intent is unambiguous.
+        called_tool = action.get("tool", "") if isinstance(action, dict) else ""
+        expected_tool = self.current_step.tool if self.current_step else None
+        if expected_tool and called_tool and called_tool != expected_tool and called_tool != "terminate":
+            logger.warning(
+                "process_action: model called '%s' but expected '%s' — rewriting tool name and clearing irrelevant args",
+                called_tool, expected_tool,
+            )
+            action["tool"] = expected_tool
+            # Clear args from the wrong tool — they don't apply to the expected tool.
+            # Auto-fill below will populate the correct required params from memory.
+            action["args"] = {}
+
         schema_properties = {}
         if action_def.parameters and "properties" in action_def.parameters:
             schema_properties = action_def.parameters["properties"]
@@ -178,7 +223,8 @@ class WorkflowCapability(Capability):
         if action_def.metadata and action_def.metadata.get("values", None):
             values = action_def.metadata.get("values")
 
-            args = action.get("args", {})
+            args = action.get("args") or {}
+            action["args"] = args  # ensure action always has a valid dict
             for key, value in values.items():
                 expected_type = schema_properties.get(key, {}).get("type")
 
@@ -212,7 +258,7 @@ class WorkflowCapability(Capability):
         required_params = action_def.parameters.get("required", []) if action_def.parameters else []
         logger.info("Required params for %s: %s", action_def.name, required_params)
         if required_params:
-            args = action.get("args", {})
+            args = action.get("args") or {}
             missing = [p for p in required_params if p not in args or args[p] is None or args[p] == ""]
             if missing:
                 logger.info(
@@ -275,30 +321,15 @@ class WorkflowCapability(Capability):
     ) -> dict | None:
         """Validate required parameters are present before hitting the API.
         Returns a synthetic error result if any required params are missing so the
-        retry logic can immediately give the LLM clear, targeted feedback."""
-
-        # Check wrong-tool FIRST — if the model called the wrong tool entirely,
-        # report that directly instead of confusing param-validation noise.
-        called_tool = action.get("tool", "") if isinstance(action, dict) else ""
-        expected_tool = self.current_step.tool if self.current_step else None
-        if expected_tool and called_tool and called_tool != expected_tool and called_tool != "terminate":
-            error_msg = (
-                f"Wrong tool: you called '{called_tool}' but the current step requires "
-                f"'{expected_tool}'. You MUST call '{expected_tool}' — do not call '{called_tool}'."
-            )
-            logger.warning("Wrong tool called: expected '%s', got '%s'", expected_tool, called_tool)
-            return {
-                "tool": called_tool,
-                "tool_executed": False,
-                "result": {"success": False, "message": error_msg},
-            }
+        retry logic can immediately give the LLM clear, targeted feedback.
+"""
 
         # process_action already auto-fills missing required params via LLM.
         # This is a last-resort safety check only — if auto-fill produced nothing,
         # surface a clear error rather than silently calling the API with missing args.
         required_params = action_def.parameters.get("required", []) if action_def.parameters else []
         if required_params:
-            args = action.get("args", {})
+            args = action.get("args") or {}
             missing = [p for p in required_params if p not in args or args[p] is None or args[p] == ""]
             if missing:
                 missing_str = ", ".join(f"'{p}'" for p in missing)
@@ -332,6 +363,7 @@ class WorkflowCapability(Capability):
             logger.warning("Terminating Workflow: %s", action.get("error"))
             self.terminate_early = True
             return result
+
         # Enhanced error detection covering multiple error scenarios
         is_error = (
             isinstance(result, dict)
@@ -359,13 +391,141 @@ class WorkflowCapability(Capability):
             )
         )
 
+        # --- Store successful step output for {{stepName.field}} references ---
+        if not is_error and self.current_step:
+            step_name = self.current_step.stepName or self.current_step.tool
+
+            # Unwrap one level: most tools return {"tool": ..., "result": {...actual data...}}
+            # Store the inner result so {{stepName.field}} navigates directly into the data.
+            if isinstance(result, dict) and "result" in result:
+                stored = result["result"]
+            else:
+                stored = result
+            # If still not a dict, wrap it so navigation works
+            if not isinstance(stored, dict):
+                stored = {"value": stored}
+
+            # --- Attempt to parse string output into declared field names ---
+            # Some tools (e.g. "think") return a plain string.  When the step has declared
+            # outputs the LLM is instructed to return a JSON object with those field names,
+            # but it often wraps the output in markdown fences (```json / ```html / etc.).
+            # If stored is {"value": "<string>"} and the step declares outputs, try to:
+            #   1. Strip markdown fences
+            #   2. JSON-parse the cleaned string
+            #   3. If it produces a dict, use it directly so {{step.field}} refs resolve.
+            if (
+                self.current_step
+                and self.current_step.outputs
+                and isinstance(stored, dict)
+                and list(stored.keys()) == ["value"]
+                and isinstance(stored.get("value"), str)
+            ):
+                raw_str = stored["value"]
+                # Strip leading/trailing whitespace then remove markdown fences
+                cleaned = raw_str.strip()
+                cleaned = re.sub(r'^```[a-zA-Z]*\s*', '', cleaned)
+                cleaned = re.sub(r'\s*```$', '', cleaned).strip()
+                try:
+                    parsed = json.loads(cleaned)
+                    if isinstance(parsed, dict):
+                        # LLM returned {"FieldName": ...} — use directly.
+                        stored = parsed
+                        logger.info(
+                            "Parsed string output for step '%s' into dict with keys=%s",
+                            step_name, list(stored.keys()),
+                        )
+                    elif (
+                        isinstance(parsed, list)
+                        and len(self.current_step.outputs) == 1
+                        and self.current_step.outputs[0].name
+                    ):
+                        # LLM returned a bare JSON array (e.g. []) instead of
+                        # {"FieldName": [...]} — wrap it under the declared output name.
+                        single_name = self.current_step.outputs[0].name
+                        stored = {single_name: parsed}
+                        logger.info(
+                            "Bare JSON array output for step '%s' — assigned list to declared output '%s'",
+                            step_name, single_name,
+                        )
+                except (json.JSONDecodeError, ValueError):
+                    # Not valid JSON — if the step declares exactly ONE output,
+                    # assign the cleaned string directly to that field name so
+                    # {{stepName.field}} can still resolve (e.g. raw HTML output).
+                    if len(self.current_step.outputs) == 1 and self.current_step.outputs[0].name:
+                        single_name = self.current_step.outputs[0].name
+                        stored = {single_name: cleaned}
+                        logger.info(
+                            "Non-JSON output for step '%s' — assigned raw string to declared output '%s'",
+                            step_name, single_name,
+                        )
+                    # else: keep the {"value": ...} wrapper
+
+            self.step_outputs[step_name] = stored
+            logger.info("Stored output for step '%s': keys=%s", step_name, list(stored.keys()) if isinstance(stored, dict) else type(stored).__name__)
+
+            # Validate declared outputs are actually present in the result
+            if self.current_step.outputs:
+                for output_attr in self.current_step.outputs:
+                    fname = output_attr.name
+                    if fname and fname not in stored:
+                        logger.warning(
+                            "Step '%s' declared output '%s' but field not found in result. "
+                            "Available keys: %s — {{%s.%s}} references will not resolve.",
+                            step_name, fname,
+                            list(stored.keys()) if isinstance(stored, dict) else "non-dict",
+                            step_name, fname,
+                        )
+
+            # --- Repeat logic ---
+            # If allowRepeat is True the step can be pushed back up to maxRepeats extra times.
+            # A step signals it is finished repeating by returning {"done": true},
+            # {"has_more": false}, or {"repeat_done": true} anywhere in its result.
+            if self.current_step.allowRepeat:
+                step_id = self._construct_step_id(self.current_step)
+                current_repeats = self.repeat_counts.get(step_id, 0)
+                max_r = self.current_step.maxRepeats if self.current_step.maxRepeats is not None else 1
+
+                # Check for explicit "done" signal from the tool result
+                result_data = result.get("result", result) if isinstance(result, dict) else {}
+                repeat_done = (
+                    result_data.get("done") is True
+                    or result_data.get("has_more") is False
+                    or result_data.get("repeat_done") is True
+                )
+
+                if repeat_done:
+                    logger.info(
+                        "-- Step '%s' signalled done — stopping repeat --",
+                        self.current_step.tool,
+                    )
+                elif current_repeats < max_r:
+                    self.repeat_counts[step_id] = current_repeats + 1
+                    logger.info(
+                        "-- Repeating step '%s' (%d/%d) --",
+                        self.current_step.tool, current_repeats + 1, max_r
+                    )
+                    self.remaining_steps.append(self.current_step)
+                    send_event = action_context.incremental_event()
+                    send_event(
+                        "workflow/step/repeat",
+                        {
+                            "workflow": self.workflow,
+                            "step": self.current_step.tool,
+                            "repeat_count": current_repeats + 1,
+                            "max_repeats": max_r,
+                        },
+                    )
+
         if is_error and self.current_step:
             step_id = self._construct_step_id(self.current_step)
             error_message = "Unknown error"
 
-            if self.retry_count[step_id] < self.max_retries:
+            if self.retry_count.get(step_id, 0) < self.max_retries:
                 logger.info(
-                    "-- Retrying step %s (%s/%s) due to error --", self.current_step.tool, self.retry_count[step_id], self.max_retries
+                    "-- Retrying step %s (%s/%s) due to error --",
+                    self.current_step.tool,
+                    self.retry_count[step_id],
+                    self.max_retries,
                 )
                 self.retry_count[step_id] += 1
                 self.remaining_steps.append(self.current_step)
@@ -394,22 +554,10 @@ class WorkflowCapability(Capability):
 
                 # Inject a retry instruction into memory so the LLM gets clear feedback.
                 if memory:
-                    called_tool = action.get("tool", "") if isinstance(action, dict) else ""
-                    expected_tool = self.current_step.tool
-                    wrong_tool = bool(called_tool and called_tool != expected_tool and called_tool != "terminate")
-
-                    if wrong_tool:
-                        retry_instruction = (
-                            f"⚠️ WRONG TOOL — You called '{called_tool}' but the current step requires "
-                            f"'{expected_tool}'. You MUST call '{expected_tool}' in your next response. "
-                            f"Do NOT call '{called_tool}' again until it is the active step."
-                        )
-                    else:
-                        retry_instruction = (
-                            f"⚠️ RETRY REQUIRED — '{self.current_step.tool}' failed with error: {error_message}\n\n"
-                            f"Please fix the issue and try again, making sure all required parameters have correct values."
-                        )
-
+                    retry_instruction = (
+                        f"⚠️ RETRY REQUIRED — '{self.current_step.tool}' failed with error: {error_message}\n\n"
+                        f"Please fix the issue and try again, making sure all required parameters have correct values."
+                    )
                     memory.add_memory({"type": "user", "content": retry_instruction})
                     logger.info("Injected retry instruction into memory for step %s", self.current_step.tool)
 
@@ -449,7 +597,7 @@ class WorkflowCapability(Capability):
                 }
             ]
 
-        if self.current_step.useAdvancedReasoning:
+        if self.current_step and self.current_step.useAdvancedReasoning:
             for m in memories:
                 if m.get("type") == "assistant":
                     content = m.get("content")
@@ -488,7 +636,72 @@ class WorkflowCapability(Capability):
     def _format_step(self, step: Step) -> str:
         return f"{step.instructions}\nTool: {step.tool}\nArgs: {step.args}"
 
+    def _resolve_references(self, value: Any) -> Any:
+        """Replace {{stepName.path.to.field}} tokens in string values with stored step outputs.
+
+        Supports:
+        - {{stepName}}               → JSON-serialised full result of that step
+        - {{stepName.field}}          → specific top-level key of the result dict
+        - {{stepName.a.b.c}}          → nested dot-path navigation
+
+        Non-string values are returned unchanged.
+        """
+        if not isinstance(value, str):
+            return value
+
+        pattern = re.compile(r"\{\{([^}]+)\}\}")
+
+        def replace_token(match: re.Match) -> str:
+            token = match.group(1).strip()
+            parts = token.split(".")
+            step_name = parts[0]
+
+            if step_name not in self.step_outputs:
+                logger.warning("Reference {{%s}} — step '%s' has no stored output yet", token, step_name)
+                return match.group(0)  # Leave unchanged if not found
+
+            node = self.step_outputs[step_name]
+
+            # Navigate dot-path if more parts exist
+            for part in parts[1:]:
+                if isinstance(node, dict) and part in node:
+                    node = node[part]
+                else:
+                    logger.warning(
+                        "Reference {{%s}} — could not navigate to '%s' in stored output", token, part
+                    )
+                    return match.group(0)  # Leave unchanged
+
+            if isinstance(node, (dict, list)):
+                return json.dumps(node)
+            return str(node)
+
+        return pattern.sub(replace_token, value)
+
+    def _resolve_step_references(self, step: Step) -> Step:
+        """Return a shallow copy of the step with all {{ref}} tokens resolved in args and values."""
+        if not self.step_outputs:
+            return step  # Nothing to resolve yet
+
+        resolved = deepcopy(step)
+
+        if resolved.args:
+            resolved.args = {k: self._resolve_references(v) for k, v in resolved.args.items()}
+
+        if resolved.values:
+            resolved.values = {k: self._resolve_references(v) for k, v in resolved.values.items()}
+
+        if resolved.instructions:
+            resolved.instructions = self._resolve_references(resolved.instructions)
+
+        return resolved
+
     def _should_skip_step(self, step: Step, action_context: ActionContext) -> bool:
+        # allowSkip=False → never skip, regardless of LLM heuristic
+        if step.allowSkip is False:
+            logger.info("-- step '%s' has allowSkip=False, skipping heuristic check --", step.tool)
+            return False
+
         if step.tool in ["terminate", "think"]:
             return False
 
@@ -524,14 +737,13 @@ Conversation history and current context:
 Respond with either YES or NO in all caps. Then write a short explanation (1-2 sentences) for your reasoning on the next line."""
 
         # llm call to determine if the step should be skipped
-        sys_prompt = """You're task is to determine if the step {step.tool} should be skipped.  
+        sys_prompt = f"""You're task is to determine if the step '{step.tool}' should be skipped.
         Use the following threshold to determine if the step should be skipped:
         CONFIDENCE THRESHOLD:
         - If you have ANY doubt (even 5%) about whether skipping is safe, respond with "NO"
-        - Only respond with "YES" if you are 100 confident this step can be safely skipped without affecting the workflow outcome
+        - Only respond with "YES" if you are 100% confident this step can be safely skipped without affecting the workflow outcome
 
-        YOUR RESPONSE MUST BE EXACTLY ONLY  YES   or   NO  in all caps. Followed by a new line and short explanation explaing your decision"""
-        f"Should we skip the step {step.tool}? {step.instructions}"
+        YOUR RESPONSE MUST BE EXACTLY ONLY  YES   or   NO  in all caps. Followed by a new line and short explanation explaining your decision."""
         response = prompt_llm_with_messages(
             action_context=action_context,
             prompt=[

--- a/amplify-agent-loop-lambda/agent/capabilities/workflow_model.py
+++ b/amplify-agent-loop-lambda/agent/capabilities/workflow_model.py
@@ -14,6 +14,12 @@ class CustomBaseModel(BaseModel):
         populate_by_name = True
 
 
+class StepOutputAttribute(CustomBaseModel):
+    name: str
+    type: Optional[str] = "string"  # string | number | boolean | object | array
+    description: Optional[str] = None
+
+
 class Step(CustomBaseModel):
     stepName: Optional[str] = None
     instructions: Optional[str] = None
@@ -26,6 +32,13 @@ class Step(CustomBaseModel):
     on_failure: Optional[Dict[str, Any]] = None
     retries: Optional[int] = Field(None, ge=0)
     timeout: Optional[int] = Field(None, ge=0)  # Timeout in seconds
+    # Output attribute declarations — describe what this step produces
+    outputs: Optional[List[StepOutputAttribute]] = None
+    # Repeat control — allow the step to loop instead of always advancing
+    allowRepeat: Optional[bool] = False
+    maxRepeats: Optional[int] = Field(None, ge=0)
+    # Skip control — None/missing = default LLM heuristic, True = allow skip check, False = never skip
+    allowSkip: Optional[bool] = None
 
 
 class Limits(CustomBaseModel):

--- a/amplify-agent-loop-lambda/agent/components/common_goals.py
+++ b/amplify-agent-loop-lambda/agent/components/common_goals.py
@@ -131,6 +131,57 @@ CAREFUL_ARGUMENT_SELECTION = Goal(
 )
 
 
+COMPLETE_ALL_REQUIRED_PARAMS = Goal(
+    name="Complete All Required Parameters",
+    description="""
+CRITICAL: You MUST provide a value for EVERY required parameter in every tool call. NEVER leave required
+parameters empty, null, or as placeholder text like "<fill in>" or "TBD".
+
+Rules:
+- If a parameter value was pre-filled via a workflow value (e.g. {{stepName.field}}), it will be resolved
+  automatically — you do not need to re-derive it.
+- If a parameter cannot be determined from context, synthesize the most reasonable value you can.
+  Making a best-effort attempt is always better than leaving the parameter blank.
+- If you are completely unable to determine a value and leaving it blank would cause total failure,
+  explain the problem and exit the loop using EXIT_AGENT_LOOP.
+""",
+)
+
+
+WORKFLOW_STRUCTURED_OUTPUT = Goal(
+    name="Workflow Structured Output",
+    description="""
+When a workflow step declares output attributes (fields that subsequent steps will reference via
+{{stepName.fieldName}}), the tool MUST return a dict/JSON object containing those exact field names as keys.
+
+Example: If step "get_email" declares output attribute "Email_Body", the tool must return:
+  {"Email_Body": "...actual html content..."}
+so the next step can reference it as {{get_email.Email_Body}}.
+
+If you are executing a "think" step that declares outputs, format your response as a JSON object
+with the declared field names as keys and the synthesized content as values.
+
+CRITICAL: If a declared output field is missing from the tool's result, any downstream step that
+references {{stepName.missingField}} will receive an unresolved token — causing incorrect behavior.
+Always verify your tool returns the declared fields.
+""",
+)
+
+
+FOLLOW_WORKFLOW_STEP_INSTRUCTIONS = Goal(
+    name="Follow Workflow Step Instructions",
+    description="""
+When executing a workflow step:
+1. The step INSTRUCTIONS are the primary directive — follow them exactly as written.
+2. Use the EXACT tool specified in the step — never substitute a different tool.
+3. Pre-filled VALUES (locked parameters) must be used exactly as provided — do not modify them.
+4. Argument HINTS (args) are guidance — adapt them to the current context if needed, but always fill them in.
+5. The step instructions override any general reasoning you might have about what to do.
+6. Complete the step as specified even if you think a different approach would be better.
+""",
+)
+
+
 ALLOW_EARLY_EXIT_AGENT_LOOP = Goal(
     name="Exit Agent Loop Early",
     description="""

--- a/amplify-agent-loop-lambda/agent/prompt.py
+++ b/amplify-agent-loop-lambda/agent/prompt.py
@@ -45,7 +45,7 @@ def generate_response(
             response = completion(
                 model=model,
                 messages=messages,
-                max_completion_tokens=1024,
+                max_completion_tokens=32768,
             )
             result = response.choices[0].message.content
         else:
@@ -54,7 +54,7 @@ def generate_response(
                 model=model,
                 messages=messages,
                 tools=tools,
-                max_completion_tokens=1024,
+                max_completion_tokens=4096,
             )
 
             if response.choices[0].message.tool_calls:

--- a/amplify-agent-loop-lambda/agent/tools/ops.py
+++ b/amplify-agent-loop-lambda/agent/tools/ops.py
@@ -295,7 +295,7 @@ def execute_api_call(
 def send_post_request(path, payload, token):
     try:
         logger.info(
-            "Sending POST request to %s with payload: %s and token: %s", path, payload, token
+            "Sending POST request to %s with payload: %s", path, payload
         )
 
         url_base = os.environ.get("API_BASE_URL")

--- a/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks.py
+++ b/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks.py
@@ -162,10 +162,15 @@ class TasksMessageHandler(MessageHandler):
         user_id = task_data.get("user") or event.get("currentUser")
         task_id = task_data.get("taskId")
 
-        # Try to extract sessionId - it might be available in task_data or we can reconstruct it
-        session_id = task_data.get("sessionId")
+        # Try to extract sessionId - check all possible locations in the event before falling back
+        session_id = (
+            task_data.get("sessionId")
+            or event.get("sessionId")
+            or event.get("metadata", {}).get("eventId")
+        )
         if not session_id and task_id:
-            # Try to reconstruct sessionId using short UUID format (best effort)
+            # Last resort: generate a new ID (will create a new entry instead of updating existing)
+            logger.warning("Could not find sessionId for task %s — failure will create a new record", task_id)
             session_id = f"execution-{str(uuid.uuid4())}"
         
         # Add sessionId to task_data for consistency


### PR DESCRIPTION
…and LLM reliability improvements

Add StepOutputAttribute, allowRepeat/maxRepeats, and allowSkip fields to the Step model Implement {{stepName.field}} token resolution — steps can reference prior step outputs in args, values, and instructions, with nested dot-path navigation and JSON serialization fallback Store step outputs after each successful execution; parse LLM string responses (stripping markdown fences) into declared output field names so downstream references resolve correctly Add repeat loop support: if allowRepeat is true, re-queue the step up to maxRepeats times until the tool signals done via done: true, has_more: false, or repeat_done: true Add allowSkip=False hard-override to bypass the LLM skip heuristic for critical steps Fix ParameterizedActionRegistry.get_action to fall through to the current parameterized step when the model calls the wrong tool name (wrong tool is now silently rewritten in process_action instead of surfacing an error) Remove wrong-tool error path from validate_required_parameters — wrong-tool rewriting now happens earlier in process_action Add three new workflow goals: FOLLOW_WORKFLOW_STEP_INSTRUCTIONS, COMPLETE_ALL_REQUIRED_PARAMS, WORKFLOW_STRUCTURED_OUTPUT Raise max_completion_tokens from 1024 → 32768 (text) and 1024 → 4096 (tool-call) to avoid truncated responses Strip auth token from POST request log line to avoid leaking credentials Fix f-string bug in _should_skip_step sys prompt (was a dead string literal, not interpolated) Fix retry_count.get() KeyError guard and useAdvancedReasoning None-guard in WorkflowCapability