### PR TITLE
Bedrock Agentcore Gateway Web Search

### DIFF
--- a/amplify-lambda-admin/requirements.txt
+++ b/amplify-lambda-admin/requirements.txt
@@ -25,3 +25,11 @@ regex==2025.9.18
     # via -r requirements.in
 sniffio==1.3.1
     # via anyio
+
+# The Bedrock AgentCore "connector" gateway target type (used for the managed
+# web search tool) is newer than the boto3/botocore bundled in the Lambda
+# python3.11 runtime. Bundle a current SDK so targetConfiguration.mcp.connector
+# is recognized. The floor just forces an upgrade above the runtime's version;
+# pip resolves to the latest release, which includes the connector target.
+boto3>=1.35.0
+botocore>=1.35.0

--- a/amplify-lambda-admin/schemata/update_admin_config_schema.py
+++ b/amplify-lambda-admin/schemata/update_admin_config_schema.py
@@ -589,12 +589,19 @@ update_admin_config_schema = {
                                         "properties": {
                                             "provider": {
                                                 "type": "string",
-                                                "enum": ["brave_search", "tavily", "serper", "serpapi"]
+                                                "enum": ["brave_search", "tavily", "serper", "serpapi", "bedrock_agentcore"]
                                             },
                                             "isEnabled": {"type": "boolean"},
                                             "allowUserWebSearchKeys": {"type": "boolean"},
                                             "webSearchUserMessage": {"type": "string"},
-                                            "api_key": {"type": "string"}
+                                            "api_key": {"type": "string"},
+                                            "bedrockAgentCoreGatewayUrl": {"type": "string"},
+                                            "bedrockAgentCoreRegion": {"type": "string"},
+                                            "bedrockAgentCoreTokenUrl": {"type": "string"},
+                                            "bedrockAgentCoreClientId": {"type": "string"},
+                                            "bedrockAgentCoreScope": {"type": "string"},
+                                            "bedrockAgentCoreToolName": {"type": "string"},
+                                            "bedrockAgentCoreAuthMode": {"type": "string"}
                                         },
                                         "required": [],
                                         "additionalProperties": False

--- a/amplify-lambda-admin/serverless.yml
+++ b/amplify-lambda-admin/serverless.yml
@@ -50,9 +50,17 @@ provider:
     LLM_ENDPOINTS_SECRETS_NAME: ${ssm:/amplify/${sls:stage}/LLM_ENDPOINTS_SECRETS_NAME}
     OAUTH_AUDIENCE: ${ssm:/amplify/${sls:stage}/OAUTH_AUDIENCE}
     OAUTH_ISSUER_BASE_URL: ${ssm:/amplify/${sls:stage}/OAUTH_ISSUER_BASE_URL}
+    COGNITO_CLIENT_ID: ${ssm:/amplify/${sls:stage}/COGNITO_CLIENT_ID, ''}
     SECRETS_ARN_NAME: ${ssm:/amplify/${sls:stage}/SECRETS_ARN_NAME}
     SERVICE_NAME: ${self:service}
     STAGE: ${sls:stage}
+
+  # Bedrock AgentCore Web Search provisioning (opt-in via stage vars; safe defaults)
+    WEB_SEARCH_AGENTCORE_ENABLED: ${self:custom.stageVars.WEB_SEARCH_AGENTCORE_ENABLED, 'false'}
+    WEB_SEARCH_AGENTCORE_AUTOENABLE: ${self:custom.stageVars.WEB_SEARCH_AGENTCORE_AUTOENABLE, 'false'}
+    WEB_SEARCH_AGENTCORE_REGION: ${self:custom.stageVars.WEB_SEARCH_AGENTCORE_REGION, 'us-east-1'}
+    WEB_SEARCH_AGENTCORE_GATEWAY_NAME: amplify-${self:custom.depName}-${sls:stage}-web-search
+    AGENTCORE_GATEWAY_ROLE_ARN: !GetAtt AgentCoreWebSearchGatewayRole.Arn
 
   # Locally Defined Variables
     AMPLIFY_ADMIN_DYNAMODB_TABLE: ${self:service}-${sls:stage}-admin-configs
@@ -230,6 +238,12 @@ functions:
           maximumBatchingWindowInSeconds: 5
           functionResponseType: ReportBatchItemFailures
 
+  provision_agentcore_web_search:
+    handler: service/agentcore_web_search_provisioner.lambda_handler
+    timeout: 300
+    description: Provisions the Bedrock AgentCore web search gateway + target (CloudFormation custom resource)
+    # No HTTP events - invoked by a CloudFormation custom resource during deploy
+
 resources:
   Resources:
 
@@ -326,6 +340,34 @@ resources:
               Action:
                 - sts:GetCallerIdentity
               Resource: "*"
+
+            # Bedrock AgentCore web search provisioning (custom resource)
+            # NOTE: gateway/target control operations use the "bedrock-agentcore:" IAM
+            # action prefix, even though the SDK client is "bedrock-agentcore-control".
+            - Effect: Allow
+              Action:
+                - bedrock-agentcore:CreateGateway
+                - bedrock-agentcore:UpdateGateway
+                - bedrock-agentcore:GetGateway
+                - bedrock-agentcore:ListGateways
+                - bedrock-agentcore:DeleteGateway
+                - bedrock-agentcore:CreateGatewayTarget
+                - bedrock-agentcore:UpdateGatewayTarget
+                - bedrock-agentcore:GetGatewayTarget
+                - bedrock-agentcore:ListGatewayTargets
+                - bedrock-agentcore:DeleteGatewayTarget
+                # Gateways provision a workload identity as a dependency
+                - bedrock-agentcore:CreateWorkloadIdentity
+                - bedrock-agentcore:GetWorkloadIdentity
+                - bedrock-agentcore:UpdateWorkloadIdentity
+                - bedrock-agentcore:DeleteWorkloadIdentity
+                - bedrock-agentcore:ListWorkloadIdentities
+              Resource: "*"
+            - Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource:
+                - !GetAtt AgentCoreWebSearchGatewayRole.Arn
             
             - Effect: Allow
               Action:
@@ -333,6 +375,40 @@ resources:
               Resource:
                 - "arn:aws:dynamodb:${aws:region}:*:table/${self:provider.environment.ADDITIONAL_CHARGES_TABLE}"
     
+    # Bedrock AgentCore Gateway service role - lets the AgentCore service invoke
+    # the gateway and the managed Web Search tool on the account's behalf.
+    AgentCoreWebSearchGatewayRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: bedrock-agentcore.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: agentcore-web-search
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Sid: InvokeGateway
+                  Effect: Allow
+                  Action: bedrock-agentcore:InvokeGateway
+                  Resource: arn:aws:bedrock-agentcore:${self:custom.stageVars.WEB_SEARCH_AGENTCORE_REGION, 'us-east-1'}:${aws:accountId}:gateway/*
+                - Sid: InvokeWebSearch
+                  Effect: Allow
+                  Action: bedrock-agentcore:InvokeWebSearch
+                  Resource: arn:aws:bedrock-agentcore:${self:custom.stageVars.WEB_SEARCH_AGENTCORE_REGION, 'us-east-1'}:aws:tool/web-search.v1
+
+    # Custom resource that creates/updates the AgentCore gateway + web search target.
+    # Re-runs on every deploy (TriggerHash). No-op unless WEB_SEARCH_AGENTCORE_ENABLED=true.
+    AgentCoreWebSearchProvision:
+      Type: Custom::AgentCoreWebSearch
+      Properties:
+        ServiceToken: !GetAtt ProvisionUnderscoreagentcoreUnderscorewebUnderscoresearchLambdaFunction.Arn
+        TriggerHash: ${sls:instanceId}
+
     AmplifyAdminTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:

--- a/amplify-lambda-admin/service/agentcore_web_search_provisioner.py
+++ b/amplify-lambda-admin/service/agentcore_web_search_provisioner.py
@@ -1,0 +1,472 @@
+"""
+Amazon Bedrock AgentCore Web Search Provisioner
+
+CloudFormation custom-resource Lambda that provisions (and tears down) the
+Amazon Bedrock AgentCore Gateway + Web Search tool target used by the
+`bedrock_agentcore` web search provider. This automates the otherwise-manual
+console setup so it ships with the rest of the services.
+
+What it does on Create/Update (when WEB_SEARCH_AGENTCORE_ENABLED=true):
+  1. Ensures an MCP Gateway exists (idempotent by name) whose inbound authorizer
+     trusts the app's existing Cognito user pool/app client. This lets the chat
+     backend authorize gateway calls with the caller's own access token
+     ("user_token" auth mode) - no extra secret to provision.
+  2. Ensures a Web Search tool target (connectorId "web-search") exists on the
+     gateway, authorized via the gateway's IAM service role.
+  3. Publishes the resulting gateway URL / region / auth mode into the admin
+     `webSearchConfig` item so the runtime can find it. It only flips the active
+     provider to `bedrock_agentcore` when auto-enable is on AND no other provider
+     is already configured (never clobbers an admin's existing choice).
+
+Design notes:
+  - Web Search connector is only available in us-east-1 today.
+  - This is intentionally FAIL-SAFE: any error (including the running boto3 not
+    yet knowing the bedrock-agentcore-control API) is logged and reported to
+    CloudFormation as SUCCESS so a brand-new capability never blocks a deploy.
+    Provisioning status is included in the response Data and the logs.
+"""
+
+import json
+import logging
+import os
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# AgentCore control-plane service name (used to create the boto3 client).
+AGENTCORE_CONTROL_SERVICE = "bedrock-agentcore-control"
+# The built-in web search connector id and tool configuration name.
+WEB_SEARCH_CONNECTOR_ID = "web-search"
+WEB_SEARCH_TOOL_CONFIG_NAME = "WebSearch"
+# Admin config item that the runtime reads.
+WEB_SEARCH_CONFIG_ID = "webSearchConfig"
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _agentcore_region() -> str:
+    # Web Search connector is us-east-1 only today; allow override but default safely.
+    return os.environ.get("WEB_SEARCH_AGENTCORE_REGION", "us-east-1")
+
+
+def _discovery_url() -> str:
+    """Build the OIDC discovery URL for the existing Cognito user pool."""
+    issuer = (os.environ.get("OAUTH_ISSUER_BASE_URL") or "").rstrip("/")
+    if not issuer:
+        return ""
+    return f"{issuer}/.well-known/openid-configuration"
+
+
+def _get_agentcore_client():
+    """
+    Create the AgentCore control-plane client. Raises if the running boto3
+    version doesn't know the service yet (caught by the fail-safe handler).
+    """
+    return boto3.client(AGENTCORE_CONTROL_SERVICE, region_name=_agentcore_region())
+
+
+# ---------------------------------------------------------------------------
+# Gateway + target management (idempotent)
+# ---------------------------------------------------------------------------
+
+def _find_gateway_by_name(client, name: str):
+    """Return the gateway summary dict whose name matches, or None."""
+    paginator_kwargs = {}
+    while True:
+        response = client.list_gateways(**paginator_kwargs)
+        for gw in response.get("items", response.get("gateways", [])):
+            if gw.get("name") == name:
+                return gw
+        next_token = response.get("nextToken")
+        if not next_token:
+            return None
+        paginator_kwargs = {"nextToken": next_token}
+
+
+def _build_authorizer_configuration():
+    """
+    Inbound JWT authorizer pointing at the existing Cognito user pool, accepting
+    the app's Cognito app client. Cognito access tokens carry `client_id`
+    (not `aud`), so we match on allowedClients.
+    """
+    discovery_url = _discovery_url()
+    client_id = os.environ.get("COGNITO_CLIENT_ID")
+    config = {"customJWTAuthorizer": {"discoveryUrl": discovery_url}}
+    if client_id:
+        config["customJWTAuthorizer"]["allowedClients"] = [client_id]
+    return config
+
+
+def _ensure_gateway(client, name: str, role_arn: str) -> dict:
+    """Create or update the MCP gateway. Returns the gateway detail dict."""
+    authorizer_config = _build_authorizer_configuration()
+    existing = _find_gateway_by_name(client, name)
+
+    common = {
+        "name": name,
+        "roleArn": role_arn,
+        "protocolType": "MCP",
+        "authorizerType": "CUSTOM_JWT",
+        "authorizerConfiguration": authorizer_config,
+        "description": "Amplify web search via Bedrock AgentCore (managed by deployment).",
+    }
+
+    if existing:
+        gateway_id = existing.get("gatewayId") or existing.get("gatewayIdentifier")
+        status = (existing.get("status") or "").upper()
+        # The list summary may not carry status; fetch the detail to be sure.
+        if not status and gateway_id:
+            try:
+                detail = client.get_gateway(gatewayIdentifier=gateway_id)
+                status = (detail.get("status") or "").upper()
+            except ClientError as e:
+                logger.warning("Could not read gateway status for %s: %s", gateway_id, str(e))
+        # A gateway stuck in FAILED can't be repaired with update_gateway (its
+        # dependencies were never created), so delete and recreate it cleanly.
+        if status == "FAILED":
+            logger.info("Existing gateway %s is in FAILED state; deleting and recreating", name)
+            _delete_gateway_and_targets(client, name)
+            # delete_gateway is async - wait for it to disappear before recreating
+            # with the same name to avoid a ConflictException.
+            if not _wait_for_gateway_deleted(client, name):
+                logger.warning("Timed out waiting for FAILED gateway %s to delete; attempting create anyway", name)
+        else:
+            logger.info("Updating existing AgentCore gateway: %s (%s)", name, gateway_id)
+            return client.update_gateway(gatewayIdentifier=gateway_id, **common)
+
+    logger.info("Creating AgentCore gateway: %s", name)
+    return _create_gateway_with_retry(client, common)
+
+
+def _gateway_identifier(gateway: dict) -> str:
+    return gateway.get("gatewayId") or gateway.get("gatewayIdentifier")
+
+
+def _wait_for_gateway_deleted(client, name: str, timeout_seconds: int = 180, poll_seconds: int = 5) -> bool:
+    """
+    Poll until no gateway with the given name exists. delete_gateway is
+    asynchronous, so we must wait before recreating with the same name to avoid
+    a ConflictException.
+    """
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if _find_gateway_by_name(client, name) is None:
+            return True
+        time.sleep(poll_seconds)
+    return False
+
+
+def _wait_for_gateway_ready(client, gateway_id: str, timeout_seconds: int = 240, poll_seconds: int = 5) -> bool:
+    """
+    Poll until the gateway reports READY. A freshly created (or just-updated)
+    gateway is transiently CREATING/UPDATING, and target creation requires a
+    READY gateway - so we must wait before creating the web search target.
+    """
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            detail = client.get_gateway(gatewayIdentifier=gateway_id)
+        except ClientError as e:
+            logger.warning("get_gateway during readiness wait failed: %s", str(e))
+            return False
+        status = (detail.get("status") or "").upper()
+        if status == "READY":
+            return True
+        if status == "FAILED":
+            logger.warning("Gateway %s entered FAILED while waiting for READY", gateway_id)
+            return False
+        time.sleep(poll_seconds)
+    logger.warning("Timed out waiting for gateway %s to become READY", gateway_id)
+    return False
+
+
+def _create_gateway_with_retry(client, common: dict, attempts: int = 6, delay_seconds: int = 10) -> dict:
+    """
+    Create the gateway, retrying on transient conflicts (e.g. the prior gateway
+    of the same name is still finishing deletion).
+    """
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return client.create_gateway(**common)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("ConflictException", "ThrottlingException", "ServiceQuotaExceededException") and attempt < attempts:
+                logger.info("create_gateway attempt %d failed with %s; retrying in %ds", attempt, code, delay_seconds)
+                last_error = e
+                time.sleep(delay_seconds)
+                continue
+            raise
+    if last_error:
+        raise last_error
+
+
+def _find_web_search_target(client, gateway_id: str):
+    """Return the web search target dict on the gateway, or None."""
+    kwargs = {"gatewayIdentifier": gateway_id}
+    while True:
+        response = client.list_gateway_targets(**kwargs)
+        for target in response.get("items", response.get("targets", [])):
+            if target.get("name") == "web-search-tool":
+                return target
+        next_token = response.get("nextToken")
+        if not next_token:
+            return None
+        kwargs = {"gatewayIdentifier": gateway_id, "nextToken": next_token}
+
+
+def _ensure_web_search_target(client, gateway_id: str) -> dict:
+    """Create the web search tool target if it doesn't already exist."""
+    target_configuration = {
+        "mcp": {
+            "connector": {
+                "source": {"connectorId": WEB_SEARCH_CONNECTOR_ID},
+                "configurations": [
+                    {"name": WEB_SEARCH_TOOL_CONFIG_NAME, "parameterValues": {}}
+                ],
+            }
+        }
+    }
+    credential_provider_configurations = [
+        {"credentialProviderType": "GATEWAY_IAM_ROLE"}
+    ]
+
+    existing = _find_web_search_target(client, gateway_id)
+    if existing:
+        logger.info("Web search target already present on gateway %s", gateway_id)
+        return existing
+
+    logger.info("Creating web search target on gateway %s", gateway_id)
+    last_error = None
+    for attempt in range(1, 7):
+        try:
+            return client.create_gateway_target(
+                gatewayIdentifier=gateway_id,
+                name="web-search-tool",
+                targetConfiguration=target_configuration,
+                credentialProviderConfigurations=credential_provider_configurations,
+            )
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            # The gateway can briefly reject target creation while it settles.
+            if code in ("ConflictException", "ValidationException", "ThrottlingException") and attempt < 6:
+                logger.info("create_gateway_target attempt %d failed with %s; retrying", attempt, code)
+                last_error = e
+                time.sleep(10)
+                continue
+            raise
+    if last_error:
+        raise last_error
+
+
+def _delete_gateway_and_targets(client, name: str) -> None:
+    """Best-effort teardown of the gateway and its targets."""
+    existing = _find_gateway_by_name(client, name)
+    if not existing:
+        logger.info("No AgentCore gateway named %s to delete", name)
+        return
+    gateway_id = _gateway_identifier(existing)
+
+    # Targets must be removed before the gateway.
+    try:
+        kwargs = {"gatewayIdentifier": gateway_id}
+        while True:
+            response = client.list_gateway_targets(**kwargs)
+            targets = response.get("items", response.get("targets", []))
+            for target in targets:
+                target_id = target.get("targetId") or target.get("targetIdentifier")
+                if target_id:
+                    client.delete_gateway_target(
+                        gatewayIdentifier=gateway_id, targetId=target_id
+                    )
+                    logger.info("Deleted gateway target %s", target_id)
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+            kwargs = {"gatewayIdentifier": gateway_id, "nextToken": next_token}
+    except ClientError as e:
+        logger.warning("Error deleting gateway targets: %s", str(e))
+
+    client.delete_gateway(gatewayIdentifier=gateway_id)
+    logger.info("Deleted AgentCore gateway %s", gateway_id)
+
+
+# ---------------------------------------------------------------------------
+# Admin config wiring (so the runtime can find the gateway)
+# ---------------------------------------------------------------------------
+
+def _publish_admin_config(gateway_url: str) -> None:
+    """
+    Merge the gateway URL / region / auth mode into the admin webSearchConfig
+    item. Only sets bedrock_agentcore as the active provider when auto-enable is
+    on AND no other provider is currently configured.
+    """
+    table_name = os.environ.get("AMPLIFY_ADMIN_DYNAMODB_TABLE")
+    if not table_name:
+        logger.warning("AMPLIFY_ADMIN_DYNAMODB_TABLE not set; skipping admin config update")
+        return
+
+    table = boto3.resource("dynamodb").Table(table_name)
+    region = _agentcore_region()
+    auto_enable = _bool_env("WEB_SEARCH_AGENTCORE_AUTOENABLE", False)
+
+    response = table.get_item(Key={"config_id": WEB_SEARCH_CONFIG_ID})
+    existing_data = (response.get("Item") or {}).get("data", {}) or {}
+    current_provider = existing_data.get("provider")
+
+    data = dict(existing_data)
+    data["bedrockAgentCoreGatewayUrl"] = gateway_url
+    data["bedrockAgentCoreRegion"] = region
+    data["bedrockAgentCoreAuthMode"] = "user_token"
+    data["allowUserWebSearchKeys"] = existing_data.get("allowUserWebSearchKeys", False)
+
+    # Only take over the active provider if asked to AND nothing else is set up.
+    if auto_enable and (not current_provider or current_provider == "bedrock_agentcore"):
+        data["provider"] = "bedrock_agentcore"
+        data["isEnabled"] = True
+        logger.info("Auto-enabling bedrock_agentcore as the active web search provider")
+    else:
+        logger.info(
+            "Storing AgentCore gateway config without changing active provider (current=%s, autoEnable=%s)",
+            current_provider, auto_enable,
+        )
+
+    table.put_item(Item={"config_id": WEB_SEARCH_CONFIG_ID, "data": data})
+
+
+def _provision() -> dict:
+    """Run the full provisioning flow and return a status dict."""
+    role_arn = os.environ.get("AGENTCORE_GATEWAY_ROLE_ARN")
+    gateway_name = os.environ.get("WEB_SEARCH_AGENTCORE_GATEWAY_NAME")
+
+    if not role_arn:
+        return {"status": "skipped", "reason": "AGENTCORE_GATEWAY_ROLE_ARN not set"}
+    if not gateway_name:
+        return {"status": "skipped", "reason": "WEB_SEARCH_AGENTCORE_GATEWAY_NAME not set"}
+    if not _discovery_url():
+        return {"status": "skipped", "reason": "OAUTH_ISSUER_BASE_URL not set"}
+
+    client = _get_agentcore_client()
+
+    gateway = _ensure_gateway(client, gateway_name, role_arn)
+    gateway_id = _gateway_identifier(gateway)
+
+    # Target creation requires a READY gateway, so wait for it to settle first.
+    _wait_for_gateway_ready(client, gateway_id)
+
+    # Re-read the gateway for a reliable URL (the create/update response may not
+    # carry the final gatewayUrl).
+    gateway_url = gateway.get("gatewayUrl") or gateway.get("gatewayEndpoint")
+    try:
+        detail = client.get_gateway(gatewayIdentifier=gateway_id)
+        gateway_url = detail.get("gatewayUrl") or detail.get("gatewayEndpoint") or gateway_url
+    except ClientError as e:
+        logger.warning("Could not re-read gateway URL: %s", str(e))
+
+    _ensure_web_search_target(client, gateway_id)
+
+    if gateway_url:
+        _publish_admin_config(gateway_url)
+
+    return {
+        "status": "provisioned",
+        "gatewayId": gateway_id,
+        "gatewayUrl": gateway_url,
+        "region": _agentcore_region(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CloudFormation custom-resource plumbing
+# ---------------------------------------------------------------------------
+
+def send_cfn_response(event, context, status, response_data):
+    """Send a response back to CloudFormation (mirrors parameter_store_populator)."""
+    import urllib3
+
+    response_body = json.dumps({
+        "Status": status,
+        "Reason": f"See CloudWatch Log Stream: {context.log_stream_name}",
+        "PhysicalResourceId": event.get("PhysicalResourceId") or context.log_stream_name,
+        "StackId": event["StackId"],
+        "RequestId": event["RequestId"],
+        "LogicalResourceId": event["LogicalResourceId"],
+        "Data": response_data,
+    })
+
+    logger.info("Sending CloudFormation response: %s", status)
+    try:
+        http = urllib3.PoolManager()
+        result = http.request(
+            "PUT",
+            event["ResponseURL"],
+            body=response_body,
+            headers={"Content-Type": "application/json"},
+        )
+        logger.info("CloudFormation response sent: %s", result.status)
+    except Exception as e:  # noqa: BLE001 - never raise from response sender
+        logger.error("Error sending CloudFormation response: %s", e)
+
+    return {"statusCode": 200}
+
+
+def handle_cloudformation_request(event, context):
+    request_type = event.get("RequestType")
+    enabled = _bool_env("WEB_SEARCH_AGENTCORE_ENABLED", False)
+
+    # Delete: best-effort teardown only when enabled; otherwise no-op.
+    if request_type == "Delete":
+        if enabled:
+            try:
+                gateway_name = os.environ.get("WEB_SEARCH_AGENTCORE_GATEWAY_NAME")
+                if gateway_name:
+                    _delete_gateway_and_targets(_get_agentcore_client(), gateway_name)
+            except Exception as e:  # noqa: BLE001 - fail-safe on delete
+                logger.warning("AgentCore teardown failed (continuing): %s", e)
+        return send_cfn_response(event, context, "SUCCESS", {"Message": "Delete handled"})
+
+    if not enabled:
+        logger.info("WEB_SEARCH_AGENTCORE_ENABLED is false; skipping AgentCore provisioning")
+        return send_cfn_response(event, context, "SUCCESS", {
+            "Message": "AgentCore web search provisioning disabled"
+        })
+
+    # Create/Update: provision, but NEVER fail the deployment if the brand-new
+    # API/permissions aren't available yet - report SUCCESS with status detail.
+    try:
+        result = _provision()
+        logger.info("AgentCore provisioning result: %s", json.dumps(result, default=str))
+        return send_cfn_response(event, context, "SUCCESS", {"Message": "OK", "Result": result})
+    except Exception as e:  # noqa: BLE001 - fail-safe so a deploy is never blocked
+        logger.error("AgentCore provisioning failed (non-blocking): %s", e, exc_info=True)
+        return send_cfn_response(event, context, "SUCCESS", {
+            "Message": "AgentCore provisioning skipped due to error (non-blocking)",
+            "Error": str(e),
+        })
+
+
+def lambda_handler(event, context):
+    logger.info("Received event: %s", json.dumps(event, default=str))
+    try:
+        if "RequestType" in event:
+            return handle_cloudformation_request(event, context)
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Direct invocation not supported. Use CloudFormation custom resource."}),
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.error("Unexpected error: %s", e, exc_info=True)
+        if "RequestType" in event:
+            return send_cfn_response(event, context, "SUCCESS", {
+                "Message": "Unexpected error (non-blocking)", "Error": str(e),
+            })
+        return {"statusCode": 500, "body": json.dumps({"error": str(e)})}

--- a/amplify-lambda-admin/service/core.py
+++ b/amplify-lambda-admin/service/core.py
@@ -498,8 +498,20 @@ def handle_critical_errors_config_update(update_data: dict) -> dict:
 
 
 # Web Search Config Constants
-WEB_SEARCH_SUPPORTED_PROVIDERS = ["brave_search", "tavily", "serper", "serpapi"]
+WEB_SEARCH_SUPPORTED_PROVIDERS = ["brave_search", "tavily", "serper", "serpapi", "bedrock_agentcore"]
 WEB_SEARCH_SSM_PREFIX = "/tools/web_search"
+
+# Extra (non-secret) configuration fields persisted alongside the provider in the
+# admin config item. Used by the Bedrock AgentCore provider, which needs a gateway
+# URL (and optionally OAuth client-credentials settings) in addition to its secret.
+WEB_SEARCH_EXTRA_CONFIG_FIELDS = [
+    "bedrockAgentCoreGatewayUrl",
+    "bedrockAgentCoreRegion",
+    "bedrockAgentCoreTokenUrl",
+    "bedrockAgentCoreClientId",
+    "bedrockAgentCoreScope",
+    "bedrockAgentCoreToolName",
+]
 
 
 def build_web_search_parameter_name(provider: str) -> str:
@@ -600,12 +612,24 @@ def handle_web_search_config_update(update_data: dict) -> dict:
                 logger.error("Error checking for API key in SSM: %s", str(e))
                 has_api_key = False
 
+    # AgentCore "user_token" auth forwards the caller's own access token to the
+    # gateway, so it can be enabled without a stored secret as long as a gateway
+    # URL is configured.
+    auth_mode = update_data.get("bedrockAgentCoreAuthMode")
+    gateway_url = update_data.get("bedrockAgentCoreGatewayUrl")
+    agentcore_keyless = (
+        provider == "bedrock_agentcore"
+        and bool(gateway_url)
+        and (auth_mode == "user_token"
+             or (not auth_mode and not update_data.get("bedrockAgentCoreTokenUrl")))
+    )
+    is_enabled = has_api_key or agentcore_keyless
+
     # Store config in DynamoDB (without the API key - that's in SSM)
-    # isEnabled is true only if an API key exists in SSM
     config_data = {
         "provider": provider,
         "allowUserWebSearchKeys": update_data.get("allowUserWebSearchKeys", False),
-        "isEnabled": has_api_key,
+        "isEnabled": is_enabled,
         "lastUpdated": datetime.now(timezone.utc).isoformat(),
     }
     # Include webSearchUserMessage if provided and non-empty after trimming
@@ -613,6 +637,14 @@ def handle_web_search_config_update(update_data: dict) -> dict:
         message = update_data["webSearchUserMessage"]
         if message and isinstance(message, str) and message.strip():
             config_data["webSearchUserMessage"] = message.strip()
+
+    # Persist provider-specific non-secret config (e.g. the Bedrock AgentCore
+    # gateway URL, OAuth settings, and auth mode). Secrets stay only in SSM.
+    for field in WEB_SEARCH_EXTRA_CONFIG_FIELDS:
+        if field in update_data:
+            value = update_data[field]
+            if value and isinstance(value, str) and value.strip():
+                config_data[field] = value.strip()
 
     result = update_admin_config_data(AdminConfigTypes.WEB_SEARCH_CONFIG.value, config_data)
 
@@ -642,24 +674,33 @@ def get_web_search_config() -> dict:
         if not provider:
             return None
 
-        # Try to get the actual key to verify it exists and mask it
+        result = {
+            "provider": provider,
+            "isEnabled": bool(config.get("isEnabled", False)),
+            "lastUpdated": config.get("lastUpdated"),
+        }
+
+        # Surface provider-specific non-secret config so the admin UI can render
+        # and edit it (e.g. the Bedrock AgentCore gateway URL and auth mode).
+        for field in WEB_SEARCH_EXTRA_CONFIG_FIELDS:
+            if field in config:
+                result[field] = config.get(field)
+
+        # Mask the stored key if one exists. AgentCore user_token mode has no
+        # stored secret, so a missing key there is expected (not "unconfigured").
         try:
             ssm_client = boto3.client("ssm")
             param_name = build_web_search_parameter_name(provider)
             ssm_response = ssm_client.get_parameter(Name=param_name, WithDecryption=True)
-            api_key = ssm_response["Parameter"]["Value"]
-
-            return {
-                "provider": provider,
-                "isEnabled": True,
-                "maskedKey": mask_api_key(api_key),
-                "lastUpdated": config.get("lastUpdated"),
-            }
+            result["maskedKey"] = mask_api_key(ssm_response["Parameter"]["Value"])
         except ClientError as e:
-            if e.response['Error']['Code'] == 'ParameterNotFound':
+            if e.response['Error']['Code'] != 'ParameterNotFound':
+                raise
+            if provider != "bedrock_agentcore":
                 # Config exists but key was deleted from SSM
                 return None
-            raise
+
+        return result
 
     except Exception as e:
         logger.error("Error getting web search config: %s", str(e))
@@ -1058,6 +1099,16 @@ def get_configs(event, context, current_user, name, data):
                         # Enrich web search config with masked API key from SSM
                         provider = new_data and new_data.get("provider")
                         if provider:
+                            # AgentCore "user_token" mode is authorized by the caller's
+                            # own token, so it has no stored secret - it's enabled by
+                            # virtue of having a gateway URL configured.
+                            auth_mode = new_data.get("bedrockAgentCoreAuthMode")
+                            agentcore_keyless = (
+                                provider == "bedrock_agentcore"
+                                and bool(new_data.get("bedrockAgentCoreGatewayUrl"))
+                                and (auth_mode == "user_token"
+                                     or (not auth_mode and not new_data.get("bedrockAgentCoreTokenUrl")))
+                            )
                             try:
                                 ssm_client = boto3.client("ssm")
                                 param_name = build_web_search_parameter_name(provider)
@@ -1067,9 +1118,10 @@ def get_configs(event, context, current_user, name, data):
                                 new_data["maskedKey"] = mask_api_key(api_key)
                             except ClientError as e:
                                 if e.response['Error']['Code'] == 'ParameterNotFound':
-                                    # Config exists but key was deleted from SSM
-                                    new_data["isEnabled"] = False
+                                    # No stored secret. Keyless AgentCore is still enabled;
+                                    # any other provider really is unconfigured.
                                     new_data["maskedKey"] = None
+                                    new_data["isEnabled"] = True if agentcore_keyless else False
                                 else:
                                     logger.error("Error getting web search API key: %s", str(e))
                                     new_data["isEnabled"] = False

--- a/amplify-lambda-js/tools/toolLoop.js
+++ b/amplify-lambda-js/tools/toolLoop.js
@@ -87,6 +87,8 @@ export async function executeToolLoop(params, messages, model, responseStream, o
     let apiKeys = await getUserToolApiKeys(userId);
      // Also check for admin-configured web search (auto-enable ONLY if frontend didn't explicitly set a preference)
     let adminKey = null;
+    // AgentCore can be authorized without a stored key (user_token / IAM gateway).
+    let webSearchKeylessAvailable = false;
 
     if (options.webSearchEnabled) {
         try {
@@ -97,6 +99,10 @@ export async function executeToolLoop(params, messages, model, responseStream, o
                 ...apiKeys,
                     [adminKey.provider]: adminKey.api_key
                 };
+            } else if (adminKey && adminKey.provider && adminKey.config?.gatewayUrl) {
+                // AgentCore gateway authorized via the caller's token (no stored secret).
+                logger.info(`Admin web search available (${adminKey.provider}, keyless), auto-enabling tool loop`);
+                webSearchKeylessAvailable = true;
             } else {
                 logger.warn("→ Web search enabled for this request but no admin API key configured");
                 options.webSearchEnabled = false;
@@ -119,8 +125,8 @@ export async function executeToolLoop(params, messages, model, responseStream, o
     // Collect all available tools
     const allTools = [];
 
-    // Add web search tool if API keys are available
-    if (Object.keys(apiKeys).length > 0) {
+    // Add web search tool if API keys are available, or AgentCore is keyless-authorized
+    if (Object.keys(apiKeys).length > 0 || webSearchKeylessAvailable) {
         allTools.push(WEB_SEARCH_TOOL_DEFINITION);
     }
 
@@ -409,8 +415,12 @@ export async function executeToolLoop(params, messages, model, responseStream, o
                         }));
                     }
                 } else {
-                    // Execute web search or other built-in tools
-                    toolResult = await executeToolCall(toolCall, apiKeys);
+                    // Execute web search or other built-in tools.
+                    // Pass the caller's access token so the AgentCore gateway can
+                    // authorize the request in user_token mode.
+                    toolResult = await executeToolCall(toolCall, apiKeys, {
+                        accessToken: params.account?.accessToken
+                    });
 
                     // Collect web search sources for display
                     if (toolName === 'web_search' && toolResult.rawResult && toolResult.rawResult.results) {

--- a/amplify-lambda-js/tools/webSearch.js
+++ b/amplify-lambda-js/tools/webSearch.js
@@ -13,6 +13,30 @@ const logger = getLogger('webSearch');
 const ssmClient = new SSMClient({});
 const dynamoClient = new DynamoDBClient({});
 
+// MCP protocol version used when talking to the Bedrock AgentCore Gateway.
+// Matches the version used by the app's existing MCP client (mcp/mcpClient.js).
+const AGENTCORE_MCP_PROTOCOL_VERSION = '2024-11-05';
+const AGENTCORE_DEFAULT_TIMEOUT_MS = 30000;
+const AGENTCORE_DEFAULT_MAX_RESULTS = 5; // matches the 5-result convention used by the other providers
+
+// In-memory cache for OAuth client-credentials access tokens, keyed by tokenUrl|clientId|scope.
+// Lives for the lifetime of the warm Lambda container so we don't mint a token per search.
+const agentCoreTokenCache = new Map();
+
+let agentCoreRpcCounter = 0;
+function nextAgentCoreRpcId() {
+    agentCoreRpcCounter += 1;
+    return `acrpc_${Date.now()}_${agentCoreRpcCounter}`;
+}
+
+function safeJsonParse(text) {
+    try {
+        return JSON.parse(text);
+    } catch (e) {
+        return null;
+    }
+}
+
 // Tool definition for LLM
 export const WEB_SEARCH_TOOL_DEFINITION = {
     type: 'function',
@@ -194,8 +218,373 @@ async function executeSerpApiSearch(query, apiKey) {
 }
 
 /**
+ * Parse a Server-Sent Events (text/event-stream) body and return the last
+ * JSON-RPC message it contains. The Bedrock AgentCore Gateway uses the MCP
+ * "Streamable HTTP" transport, which may answer a request with either a plain
+ * JSON body or a single SSE event, depending on content negotiation.
+ */
+function parseSSEJsonRpc(text) {
+    const dataPayloads = [];
+    for (const rawLine of text.split(/\r?\n/)) {
+        const line = rawLine.replace(/\s+$/, '');
+        if (line.startsWith('data:')) {
+            dataPayloads.push(line.slice(5).trim());
+        }
+    }
+
+    let lastMessage = null;
+    for (const payload of dataPayloads) {
+        if (!payload) continue;
+        const obj = safeJsonParse(payload);
+        if (obj && (obj.result !== undefined || obj.error !== undefined || obj.jsonrpc)) {
+            lastMessage = obj;
+        }
+    }
+
+    if (lastMessage) return lastMessage;
+    // Fall back to parsing the whole body as JSON (some gateways send raw JSON in SSE).
+    return safeJsonParse(text);
+}
+
+/**
+ * Make a single JSON-RPC call to an MCP endpoint (the AgentCore Gateway URL).
+ * Handles both JSON and SSE responses and surfaces the MCP session id header so
+ * the caller can thread it through subsequent requests.
+ *
+ * @returns {Object} { sessionId, body }
+ */
+async function agentCoreMcpRpc(url, headers, message, timeoutMs) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(message),
+            signal: controller.signal
+        });
+
+        const sessionId = response.headers.get('mcp-session-id');
+
+        if (!response.ok) {
+            const errorText = await response.text().catch(() => '');
+            throw new Error(`AgentCore gateway HTTP ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`);
+        }
+
+        const contentType = (response.headers.get('content-type') || '').toLowerCase();
+        let body = null;
+
+        if (contentType.includes('text/event-stream')) {
+            body = parseSSEJsonRpc(await response.text());
+        } else if (contentType.includes('application/json')) {
+            body = await response.json();
+        } else {
+            // Notifications (e.g. notifications/initialized) typically return 202 with an empty body.
+            const text = await response.text();
+            body = text ? safeJsonParse(text) : null;
+        }
+
+        return { sessionId, body };
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            throw new Error('AgentCore gateway request timed out');
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+/**
+ * Determine which auth mode to use for the AgentCore gateway.
+ *   - explicit config.authMode wins
+ *   - tokenUrl + clientId -> OAuth2 client-credentials
+ *   - a secret present -> static bearer token
+ *   - otherwise -> user_token (forward the caller's Cognito access token)
+ */
+function resolveAgentCoreAuthMode(config = {}, secret) {
+    if (config.authMode) return config.authMode;
+    if (config.tokenUrl && config.clientId) return 'oauth';
+    if (secret) return 'bearer';
+    return 'user_token';
+}
+
+/**
+ * Obtain a bearer token for the AgentCore Gateway.
+ *
+ * AgentCore Gateways enforce inbound OAuth/JWT authorization. Three modes are
+ * supported:
+ *   1. user_token: forward the caller's own Cognito access token. The gateway's
+ *      JWT authorizer is configured to trust the app's Cognito user pool/client,
+ *      so no extra secret needs to be provisioned. This is the default for the
+ *      automated deployment path.
+ *   2. oauth: OAuth2 client-credentials flow (config.tokenUrl + config.clientId);
+ *      `secret` is the client secret. Tokens are cached until shortly before expiry.
+ *   3. bearer: `secret` is used directly as a static bearer token.
+ *
+ * @param {Object} config - { authMode, tokenUrl, clientId, scope }
+ * @param {string} secret - client secret (OAuth) or static bearer token
+ * @param {string} accessToken - caller's access token (user_token mode)
+ * @returns {string} bearer token
+ */
+async function getAgentCoreAccessToken(config = {}, secret, accessToken) {
+    const authMode = resolveAgentCoreAuthMode(config, secret);
+
+    if (authMode === 'user_token') {
+        if (!accessToken) {
+            throw new Error('Bedrock AgentCore user_token auth requires the caller access token');
+        }
+        return accessToken;
+    }
+
+    if (authMode === 'bearer') {
+        if (!secret) {
+            throw new Error('Bedrock AgentCore bearer auth requires a token');
+        }
+        return secret;
+    }
+
+    // OAuth2 client-credentials flow
+    const { tokenUrl, clientId, scope } = config;
+    if (!tokenUrl || !clientId) {
+        throw new Error('Bedrock AgentCore oauth auth requires tokenUrl and clientId');
+    }
+    if (!secret) {
+        throw new Error('Bedrock AgentCore OAuth client-credentials flow requires a client secret');
+    }
+
+    const cacheKey = `${tokenUrl}|${clientId}|${scope || ''}`;
+    const now = Date.now();
+    const cached = agentCoreTokenCache.get(cacheKey);
+    // Reuse the cached token if it has more than 60s of life left.
+    if (cached && cached.expiresAt > now + 60000) {
+        return cached.token;
+    }
+
+    const form = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: secret
+    });
+    if (scope) {
+        form.set('scope', scope);
+    }
+
+    const response = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: form.toString()
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`AgentCore OAuth token request failed: ${response.status}${errorText ? ` - ${errorText}` : ''}`);
+    }
+
+    const data = await response.json();
+    const token = data.access_token;
+    if (!token) {
+        throw new Error('AgentCore OAuth token response did not include an access_token');
+    }
+
+    const expiresInMs = (typeof data.expires_in === 'number' ? data.expires_in : 3600) * 1000;
+    agentCoreTokenCache.set(cacheKey, { token, expiresAt: now + expiresInMs });
+    return token;
+}
+
+/**
+ * Pick the web search tool name from the gateway's tool list.
+ *
+ * AgentCore Gateways namespace target tool names (e.g. "web-search-tool___WebSearch"),
+ * so we discover the actual name rather than hardcoding it. An explicit
+ * config.toolName always wins.
+ */
+function resolveAgentCoreWebSearchToolName(tools, configuredName) {
+    if (configuredName) return configuredName;
+
+    if (!Array.isArray(tools) || tools.length === 0) {
+        throw new Error('AgentCore gateway exposed no tools (check the gateway target configuration)');
+    }
+    if (tools.length === 1) {
+        return tools[0].name;
+    }
+
+    const lower = (name) => (name || '').toLowerCase();
+    const byWebSearch = tools.find(t => lower(t.name).includes('websearch'));
+    if (byWebSearch) return byWebSearch.name;
+
+    const bySearch = tools.find(t => /search/i.test(t.name));
+    if (bySearch) return bySearch.name;
+
+    return tools[0].name;
+}
+
+/**
+ * Normalize the AgentCore Web Search tool result into the standard
+ * { title, url, description } shape used across the app.
+ */
+function parseAgentCoreResults(toolResult, maxResults) {
+    if (!toolResult) return [];
+
+    // Collect every candidate payload: structuredContent (if present) and any
+    // JSON parsed from text content items. The gateway may return results in
+    // either place, so we pick whichever actually carries a results array
+    // rather than assuming one source.
+    const candidates = [];
+    if (toolResult.structuredContent && typeof toolResult.structuredContent === 'object') {
+        candidates.push(toolResult.structuredContent);
+    }
+    if (Array.isArray(toolResult.content)) {
+        for (const item of toolResult.content) {
+            if (item?.type === 'text' && item.text) {
+                const parsed = safeJsonParse(item.text);
+                if (parsed) candidates.push(parsed);
+            }
+        }
+    }
+
+    let items = [];
+    for (const candidate of candidates) {
+        if (candidate && Array.isArray(candidate.results)) {
+            items = candidate.results;
+            break;
+        }
+        if (Array.isArray(candidate)) {
+            items = candidate;
+            break;
+        }
+    }
+
+    return items.slice(0, maxResults).map(result => ({
+        title: result.title || result.url || 'Untitled',
+        url: result.url || '',
+        description: result.text || result.snippet || result.description || ''
+    }));
+}
+
+/**
+ * Extract a human-readable error message from an MCP tool result.
+ */
+function extractAgentCoreText(toolResult) {
+    if (toolResult && Array.isArray(toolResult.content)) {
+        const textItem = toolResult.content.find(item => item.type === 'text' && item.text);
+        if (textItem) return textItem.text;
+    }
+    return 'Unknown error';
+}
+
+/**
+ * Execute a web search via the Amazon Bedrock AgentCore Gateway Web Search tool.
+ *
+ * Unlike the REST providers, this talks to an MCP endpoint (the gateway URL):
+ *   initialize -> notifications/initialized -> tools/list (if needed) -> tools/call
+ *
+ * @param {string} query - search query
+ * @param {string} secret - OAuth client secret or static bearer token (from SSM)
+ * @param {Object} config - { gatewayUrl, authMode, tokenUrl, clientId, scope, toolName, region, maxResults, timeoutMs }
+ * @param {string} accessToken - caller's Cognito access token (used in user_token auth mode)
+ */
+async function executeBedrockAgentCoreSearch(query, secret, config = {}, accessToken) {
+    const gatewayUrl = config.gatewayUrl;
+    if (!gatewayUrl) {
+        throw new Error('Bedrock AgentCore web search requires a configured gateway URL (bedrockAgentCoreGatewayUrl)');
+    }
+
+    const token = await getAgentCoreAccessToken(config, secret, accessToken);
+    if (!token) {
+        throw new Error('Bedrock AgentCore web search requires a bearer token, OAuth client credentials, or a caller access token');
+    }
+
+    const timeoutMs = config.timeoutMs || AGENTCORE_DEFAULT_TIMEOUT_MS;
+    const baseHeaders = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'Authorization': `Bearer ${token}`
+    };
+
+    // 1. initialize the MCP session
+    const initResponse = await agentCoreMcpRpc(gatewayUrl, baseHeaders, {
+        jsonrpc: '2.0',
+        id: nextAgentCoreRpcId(),
+        method: 'initialize',
+        params: {
+            protocolVersion: AGENTCORE_MCP_PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            clientInfo: { name: 'amplify-genai', version: '1.0.0' }
+        }
+    }, timeoutMs);
+
+    if (initResponse.body?.error) {
+        throw new Error(`AgentCore gateway initialize failed: ${initResponse.body.error.message}`);
+    }
+
+    // Thread the MCP session id (if the gateway issued one) through later requests.
+    const sessionHeaders = initResponse.sessionId
+        ? { ...baseHeaders, 'Mcp-Session-Id': initResponse.sessionId }
+        : baseHeaders;
+
+    // 2. tell the server initialization is complete (best-effort notification)
+    try {
+        await agentCoreMcpRpc(gatewayUrl, sessionHeaders, {
+            jsonrpc: '2.0',
+            method: 'notifications/initialized',
+            params: {}
+        }, timeoutMs);
+    } catch (notifyError) {
+        logger.debug(`AgentCore initialized notification skipped: ${notifyError.message}`);
+    }
+
+    // 3. resolve the tool name (discover via tools/list unless explicitly configured)
+    let toolName = config.toolName;
+    if (!toolName) {
+        const listResponse = await agentCoreMcpRpc(gatewayUrl, sessionHeaders, {
+            jsonrpc: '2.0',
+            id: nextAgentCoreRpcId(),
+            method: 'tools/list',
+            params: {}
+        }, timeoutMs);
+
+        if (listResponse.body?.error) {
+            throw new Error(`AgentCore gateway tools/list failed: ${listResponse.body.error.message}`);
+        }
+        toolName = resolveAgentCoreWebSearchToolName(listResponse.body?.result?.tools, config.toolName);
+    }
+
+    // 4. call the web search tool
+    const maxResults = Math.min(Math.max(parseInt(config.maxResults, 10) || AGENTCORE_DEFAULT_MAX_RESULTS, 1), 25);
+    const callResponse = await agentCoreMcpRpc(gatewayUrl, sessionHeaders, {
+        jsonrpc: '2.0',
+        id: nextAgentCoreRpcId(),
+        method: 'tools/call',
+        params: {
+            name: toolName,
+            arguments: { query, maxResults }
+        }
+    }, timeoutMs);
+
+    if (callResponse.body?.error) {
+        throw new Error(`AgentCore web search failed: ${callResponse.body.error.message}`);
+    }
+
+    const toolResult = callResponse.body?.result;
+    if (toolResult?.isError) {
+        throw new Error(`AgentCore web search returned an error: ${extractAgentCoreText(toolResult)}`);
+    }
+
+    const results = parseAgentCoreResults(toolResult, maxResults);
+
+    return {
+        provider: 'bedrock_agentcore',
+        query,
+        results,
+        resultCount: results.length
+    };
+}
+
+/**
  * Get the admin-configured web search API key from SSM and DynamoDB
- * @returns {Object|null} { provider, api_key } or null if not configured
+ * @returns {Object|null} { provider, api_key, config } or null if not configured
  */
 export async function getAdminWebSearchApiKey() {
     const adminTableName = process.env.AMPLIFY_ADMIN_DYNAMODB_TABLE;
@@ -232,27 +621,58 @@ export async function getAdminWebSearchApiKey() {
             return null;
         }
 
-        const provider = response.Item.data.M.provider.S;
+        const data = response.Item.data.M;
+        const provider = data.provider.S;
         const paramName = `/tools/web_search/${provider}/${stage}`;
 
-        // Get API key from SSM
-        const ssmCommand = new GetParameterCommand({
-            Name: paramName,
-            WithDecryption: true
-        });
-
-        const ssmResponse = await ssmClient.send(ssmCommand);
-        const apiKey = ssmResponse.Parameter?.Value;
-
-        if (!apiKey) {
-            logger.warn(`Admin web search key not found in SSM: ${paramName}`);
-            return null;
+        // For the Bedrock AgentCore provider, pull the extra (non-secret) gateway
+        // configuration that lives alongside the provider in the admin config item.
+        // Falls back to environment variables published by the deployment-time
+        // provisioner so the gateway is usable even before an admin edits the config.
+        let config;
+        if (provider === 'bedrock_agentcore') {
+            config = {
+                gatewayUrl: data.bedrockAgentCoreGatewayUrl?.S || process.env.WEB_SEARCH_AGENTCORE_GATEWAY_URL || undefined,
+                region: data.bedrockAgentCoreRegion?.S || process.env.WEB_SEARCH_AGENTCORE_REGION || undefined,
+                authMode: data.bedrockAgentCoreAuthMode?.S || process.env.WEB_SEARCH_AGENTCORE_AUTH_MODE || undefined,
+                tokenUrl: data.bedrockAgentCoreTokenUrl?.S,
+                clientId: data.bedrockAgentCoreClientId?.S,
+                scope: data.bedrockAgentCoreScope?.S,
+                toolName: data.bedrockAgentCoreToolName?.S
+            };
         }
 
-        logger.info(`Using admin web search key for provider: ${provider}`);
+        // Get API key from SSM. The AgentCore "user_token" auth mode forwards the
+        // caller's own access token to the gateway, so no stored secret is required.
+        let apiKey;
+        try {
+            const ssmResponse = await ssmClient.send(new GetParameterCommand({
+                Name: paramName,
+                WithDecryption: true
+            }));
+            apiKey = ssmResponse.Parameter?.Value;
+        } catch (ssmError) {
+            if (ssmError.name !== 'ParameterNotFound') {
+                throw ssmError;
+            }
+        }
+
+        if (!apiKey) {
+            const usesUserToken = provider === 'bedrock_agentcore'
+                && (config?.authMode === 'user_token'
+                    || (!config?.authMode && !config?.tokenUrl && !config?.clientId));
+            if (!(usesUserToken && config?.gatewayUrl)) {
+                logger.warn(`Admin web search key not found in SSM: ${paramName}`);
+                return null;
+            }
+            logger.info('AgentCore user_token auth mode: proceeding without a stored secret');
+        }
+
+        logger.info(`Using admin web search config for provider: ${provider}`);
         return {
             provider,
-            api_key: apiKey
+            api_key: apiKey,
+            config
         };
 
     } catch (error) {
@@ -270,9 +690,10 @@ export async function getAdminWebSearchApiKey() {
  * @param {string} query - The search query
  * @param {Object} apiKeys - Object with provider keys { brave_search: 'key', tavily: 'key', serper: 'key', serpapi: 'key' }
  * @param {boolean} skipAdminKey - If true, skip checking for admin key (used when user keys are explicitly provided)
+ * @param {Object} context - Optional runtime context, e.g. { accessToken } used by the AgentCore user_token auth mode
  * @returns {Object} Search results
  */
-export async function executeWebSearch(query, apiKeys = {}, skipAdminKey = false) {
+export async function executeWebSearch(query, apiKeys = {}, skipAdminKey = false, context = {}) {
     // Validate query parameter
     if (!query || typeof query !== 'string') {
         throw new Error('Search query is required and must be a string');
@@ -296,20 +717,30 @@ export async function executeWebSearch(query, apiKeys = {}, skipAdminKey = false
         { name: 'brave_search', execute: executeBraveSearch },
         { name: 'tavily', execute: executeTavilySearch },
         { name: 'serper', execute: executeSerperSearch },
-        { name: 'serpapi', execute: executeSerpApiSearch }
+        { name: 'serpapi', execute: executeSerpApiSearch },
+        { name: 'bedrock_agentcore', execute: executeBedrockAgentCoreSearch }
     ];
+
+    // Per-provider non-secret configuration (e.g. AgentCore gateway URL / OAuth settings).
+    // The REST providers ignore this; only bedrock_agentcore consumes it.
+    const providerConfigs = {};
 
     // First, check for admin-configured API key if not skipped
     if (!skipAdminKey) {
         try {
             const adminKey = await getAdminWebSearchApiKey();
-            if (adminKey && adminKey.provider && adminKey.api_key) {
-                logger.info(`Found admin-configured web search key for provider: ${adminKey.provider}`);
-                // Merge admin key with user keys, giving priority to admin key's provider
-                apiKeys = {
-                    ...apiKeys,
-                    [adminKey.provider]: adminKey.api_key
-                };
+            if (adminKey && adminKey.provider) {
+                logger.info(`Found admin-configured web search provider: ${adminKey.provider}`);
+                // The key may be absent for AgentCore user_token mode (no stored secret).
+                if (adminKey.api_key) {
+                    apiKeys = {
+                        ...apiKeys,
+                        [adminKey.provider]: adminKey.api_key
+                    };
+                }
+                if (adminKey.config) {
+                    providerConfigs[adminKey.provider] = adminKey.config;
+                }
             }
         } catch (error) {
             logger.warn('Failed to get admin web search key, falling back to user keys:', error.message);
@@ -322,16 +753,24 @@ export async function executeWebSearch(query, apiKeys = {}, skipAdminKey = false
 
     for (const provider of providers) {
         const apiKey = apiKeys[provider.name];
-        if (apiKey) {
-            try {
-                logger.info(`Using ${provider.name} for web search`);
-                const result = await provider.execute(trimmedQuery, apiKey);
-                logger.info(`Web search completed with ${result.resultCount} results`);
-                return result;
-            } catch (error) {
-                logger.error(`${provider.name} search failed:`, error.message);
-                // Try next provider
-            }
+        const config = providerConfigs[provider.name];
+
+        // AgentCore can run without a stored key (user_token / IAM-authorized gateway)
+        // as long as it has a gateway URL to talk to.
+        const isAgentCore = provider.name === 'bedrock_agentcore';
+        const runnable = apiKey || (isAgentCore && config?.gatewayUrl);
+        if (!runnable) {
+            continue;
+        }
+
+        try {
+            logger.info(`Using ${provider.name} for web search`);
+            const result = await provider.execute(trimmedQuery, apiKey, config, context.accessToken);
+            logger.info(`Web search completed with ${result.resultCount} results`);
+            return result;
+        } catch (error) {
+            logger.error(`${provider.name} search failed:`, error.message);
+            // Try next provider
         }
     }
 
@@ -378,9 +817,10 @@ export function formatSearchResultsForLLM(searchResult) {
  * Execute a tool call
  * @param {Object} toolCall - The tool call from LLM
  * @param {Object} apiKeys - User's API keys
+ * @param {Object} context - Optional runtime context, e.g. { accessToken } for AgentCore user_token auth
  * @returns {Object} Tool result
  */
-export async function executeToolCall(toolCall, apiKeys) {
+export async function executeToolCall(toolCall, apiKeys, context = {}) {
     const toolName = toolCall.function?.name || toolCall.name;
     let args = {};
 
@@ -396,7 +836,7 @@ export async function executeToolCall(toolCall, apiKeys) {
 
     switch (toolName) {
         case 'web_search':
-            const searchResult = await executeWebSearch(args.query, apiKeys);
+            const searchResult = await executeWebSearch(args.query, apiKeys, false, context);
             return {
                 callId: toolCall.id,
                 toolName,

--- a/dev-var.yml-example
+++ b/dev-var.yml-example
@@ -45,4 +45,12 @@ MAX_ACU: "16"
 # Var for Admin interface access
 ADMINS: "" #CSV list of email usernames that need admin access. Can add secondary admins once deployed
 
+# Bedrock AgentCore Web Search (optional web search provider)
+# When enabled, deployment provisions an AgentCore Gateway + Web Search tool target automatically.
+# Requires the running admin Lambda's boto3 to support 'bedrock-agentcore-control' and the
+# Web Search connector (currently us-east-1 only). Safe to leave false.
+WEB_SEARCH_AGENTCORE_ENABLED: false #true to auto-provision the AgentCore web search gateway on deploy
+WEB_SEARCH_AGENTCORE_AUTOENABLE: false #true to make bedrock_agentcore the active provider when none is configured
+WEB_SEARCH_AGENTCORE_REGION: "us-east-1" #region for the AgentCore gateway/web search connector
+
 LOG_LEVEL: "INFO" # Valid Values Include: DEBUG | INFO | WARNING | ERROR | CRITICAL


### PR DESCRIPTION
Added support for Bedrcok AgentCore Web Search as a web search provider type.

Without configuration, this is no-op/no impact. To enable, configure new <env>-var parameters documented in the template.

_Requires update to Front End as well._