### PR TITLE
Enhance Scheduled Tasks

### DIFF
--- a/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks.py
+++ b/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks.py
@@ -1072,6 +1072,37 @@ def find_tasks_to_execute():
                             f"Note: {len(due_instances_utc) - 1} additional instance(s) pending"
                         )
 
+                    # 5a. Check exclusion rules
+                    if task.get("exclusionsEnabled"):
+                        excluded_days   = task.get("excludedDaysOfWeek", []) or []
+                        excluded_weeks  = [int(w) for w in (task.get("excludedWeeksOfMonth", []) or [])]
+                        excluded_months = task.get("excludedMonths", []) or []
+                        excluded_dates  = task.get("excludedDates", []) or []
+
+                        run_dt = earliest_due_instance_user_tz
+                        day_name = run_dt.strftime("%a").upper()  # MON, TUE, ...
+
+                        # Week-of-month (1 = first week, 5 = fifth/last)
+                        week_of_month = (run_dt.day - 1) // 7 + 1
+
+                        month_name = run_dt.strftime("%b").upper()  # JAN, FEB, ...
+                        date_str = run_dt.strftime("%Y-%m-%d")
+
+                        is_excluded = (
+                            day_name in excluded_days
+                            or week_of_month in excluded_weeks
+                            or month_name in excluded_months
+                            or date_str in excluded_dates
+                        )
+
+                        if is_excluded:
+                            logger.info(
+                                f"Task {task_id} instance {run_dt.strftime('%Y-%m-%d %H:%M %Z')} "
+                                f"skipped by exclusion rules (day={day_name}, week={week_of_month}, "
+                                f"month={month_name}, date={date_str})"
+                            )
+                            continue
+
                 except Exception as e:
                     logger.error(f"Error with croniter for task {task_id}: {e}. Skipping.", exc_info=True)
                     continue

--- a/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks_registry.py
+++ b/amplify-agent-loop-lambda/scheduled_tasks_events/scheduled_tasks_registry.py
@@ -30,6 +30,11 @@ def create_scheduled_task(
     access_token=None,
     account=None,
     time_zone=None,
+    exclusions_enabled=None,
+    excluded_days_of_week=None,
+    excluded_weeks_of_month=None,
+    excluded_months=None,
+    excluded_dates=None,
 ):
     """
     Create a new scheduled task.
@@ -112,6 +117,16 @@ def create_scheduled_task(
         item["notifyOnFailure"] = serializer.serialize(notify_on_failure)
     if notify_email_addresses:
         item["notifyEmailAddresses"] = serializer.serialize(notify_email_addresses)
+    if exclusions_enabled is not None:
+        item["exclusionsEnabled"] = serializer.serialize(exclusions_enabled)
+    if excluded_days_of_week is not None:
+        item["excludedDaysOfWeek"] = serializer.serialize(excluded_days_of_week)
+    if excluded_weeks_of_month is not None:
+        item["excludedWeeksOfMonth"] = serializer.serialize(excluded_weeks_of_month)
+    if excluded_months is not None:
+        item["excludedMonths"] = serializer.serialize(excluded_months)
+    if excluded_dates is not None:
+        item["excludedDates"] = serializer.serialize(excluded_dates)
 
     try:
         # Insert the task into the DynamoDB table
@@ -188,6 +203,13 @@ def get_scheduled_task(current_user, task_id, access_token=None):
             result["notifyOnFailure"] = task["notifyOnFailure"]
         if "notifyEmailAddresses" in task:
             result["notifyEmailAddresses"] = task["notifyEmailAddresses"]
+
+        # Always return exclusion fields so frontend gets consistent data
+        result["exclusionsEnabled"] = bool(task.get("exclusionsEnabled", False))
+        result["excludedDaysOfWeek"] = list(task.get("excludedDaysOfWeek", []) or [])
+        result["excludedWeeksOfMonth"] = [int(w) for w in (task.get("excludedWeeksOfMonth", []) or [])]
+        result["excludedMonths"] = list(task.get("excludedMonths", []) or [])
+        result["excludedDates"] = list(task.get("excludedDates", []) or [])
 
         return result
 
@@ -289,6 +311,11 @@ def update_scheduled_task(
     notify_on_failure=None,
     notify_email_addresses=None,
     time_zone=None,
+    exclusions_enabled=None,
+    excluded_days_of_week=None,
+    excluded_weeks_of_month=None,
+    excluded_months=None,
+    excluded_dates=None,
 ):
     """
     Update an existing scheduled task.
@@ -330,8 +357,8 @@ def update_scheduled_task(
         expression_attribute_names = {}
         expression_attribute_values = {}
 
-        def add_to_update(field_name, param_value, dynamo_field=None):
-            if param_value is not None:
+        def add_to_update(field_name, param_value, dynamo_field=None, always=False):
+            if param_value is not None or always:
                 if dynamo_field is None:
                     dynamo_field = field_name
                 placeholder = f":val{len(expression_attribute_values)}"
@@ -357,6 +384,11 @@ def update_scheduled_task(
         add_to_update("notifyEmailAddresses", notify_email_addresses)
         add_to_update("updatedAt", datetime.now().isoformat())
         add_to_update("timeZone", time_zone)
+        add_to_update("exclusionsEnabled", exclusions_enabled if exclusions_enabled is not None else False, always=True)
+        add_to_update("excludedDaysOfWeek", excluded_days_of_week or [], always=True)
+        add_to_update("excludedWeeksOfMonth", excluded_weeks_of_month or [], always=True)
+        add_to_update("excludedMonths", excluded_months or [], always=True)
+        add_to_update("excludedDates", excluded_dates or [], always=True)
 
         # If nothing to update
         if not update_expression_parts:

--- a/amplify-agent-loop-lambda/service/scheduled_task_handlers.py
+++ b/amplify-agent-loop-lambda/service/scheduled_task_handlers.py
@@ -82,6 +82,30 @@ logger = getLogger("scheduled_task_handlers")
                 "description": "Email addresses to notify (optional)",
             },
             "timeZone": {"type": "string", "description": "Time zone for scheduling"},
+            "exclusionsEnabled": {
+                "type": "boolean",
+                "description": "Whether the exclusion rules panel is enabled",
+            },
+            "excludedDaysOfWeek": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Days of the week to skip (e.g. ['MON', 'FRI'])",
+            },
+            "excludedWeeksOfMonth": {
+                "type": "array",
+                "items": {"type": "number"},
+                "description": "Weeks of the month to skip (1-5)",
+            },
+            "excludedMonths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Months to skip (e.g. ['JAN', 'JUL'])",
+            },
+            "excludedDates": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Specific dates to skip (ISO format)",
+            },
         },
         "required": [
             "taskName",
@@ -125,6 +149,11 @@ def create_scheduled_task_handler(
     notify_on_failure=False,
     notify_email_addresses=None,
     time_zone=None,
+    exclusions_enabled=None,
+    excluded_days_of_week=None,
+    excluded_weeks_of_month=None,
+    excluded_months=None,
+    excluded_dates=None,
 ):
     try:
         logger.info("Creating scheduled task with object_info: %s", object_info)
@@ -145,6 +174,11 @@ def create_scheduled_task_handler(
             access_token=access_token,
             account=account_id,
             time_zone=time_zone,
+            exclusions_enabled=exclusions_enabled,
+            excluded_days_of_week=excluded_days_of_week,
+            excluded_weeks_of_month=excluded_weeks_of_month,
+            excluded_months=excluded_months,
+            excluded_dates=excluded_dates,
         )
         return {
             "success": True,
@@ -336,6 +370,30 @@ def list_scheduled_tasks_handler(current_user, access_token):
                 "description": "Email addresses to notify (optional)",
             },
             "timeZone": {"type": "string", "description": "Time zone for scheduling"},
+            "exclusionsEnabled": {
+                "type": "boolean",
+                "description": "Whether the exclusion rules panel is enabled",
+            },
+            "excludedDaysOfWeek": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Days of the week to skip (e.g. ['MON', 'FRI'])",
+            },
+            "excludedWeeksOfMonth": {
+                "type": "array",
+                "items": {"type": "number"},
+                "description": "Weeks of the month to skip (1-5)",
+            },
+            "excludedMonths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Months to skip (e.g. ['JAN', 'JUL'])",
+            },
+            "excludedDates": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Specific dates to skip (ISO format)",
+            },
         },
         "required": ["taskId"],
     },
@@ -368,6 +426,11 @@ def update_scheduled_task_handler(
     notify_on_failure=None,
     notify_email_addresses=None,
     time_zone=None,
+    exclusions_enabled=None,
+    excluded_days_of_week=None,
+    excluded_weeks_of_month=None,
+    excluded_months=None,
+    excluded_dates=None,
 ):
     try:
         result = update_scheduled_task(
@@ -386,6 +449,11 @@ def update_scheduled_task_handler(
             notify_on_failure=notify_on_failure,
             notify_email_addresses=notify_email_addresses,
             time_zone=time_zone,
+            exclusions_enabled=exclusions_enabled,
+            excluded_days_of_week=excluded_days_of_week,
+            excluded_weeks_of_month=excluded_weeks_of_month,
+            excluded_months=excluded_months,
+            excluded_dates=excluded_dates,
         )
         return result
     except Exception as e:


### PR DESCRIPTION
Enhance Scheduled Tasks

Added an exclusion section to the scheduled time configuration section.
Schedule task log adding the clear header
Fixed the schedule task UI bug where switching between tasks (e.g., from Happy Testing to Testing) after clicking run task shows the wrong task's logs
