### PR TITLE
Enhance attachment handling: stage large files in S3 and return pre-signed URLs

### DIFF
--- a/amplify-lambda-assistants-api-office365/integrations/o365/attachment_staging.py
+++ b/amplify-lambda-assistants-api-office365/integrations/o365/attachment_staging.py
@@ -1,0 +1,68 @@
+import os
+import re
+import uuid
+
+import boto3
+from botocore.client import Config
+from pycommon.logger import getLogger
+
+logger = getLogger("o365.attachment_staging")
+
+# How long a staged-attachment download URL stays valid. Objects themselves
+# are cleaned up by the staging bucket's lifecycle rule (1 day).
+DOWNLOAD_URL_TTL_SECONDS = 900  # 15 minutes
+
+
+class AttachmentStagingError(Exception):
+    """Raised when an attachment cannot be staged for download."""
+
+    pass
+
+
+def stage_attachment_for_download(content: bytes, name: str, content_type: str) -> str:
+    """
+    Uploads attachment bytes to the staging bucket and returns a pre-signed GET
+    URL the caller can fetch WITHOUT any auth header.
+
+    Attachments over the direct-response size limit can't be returned through
+    API Gateway (10MB response limit), and the raw Graph $value URL is useless
+    to callers — it requires OUR Graph access token, which they don't have.
+    Staging in S3 gives them a URL that actually works.
+
+    Args:
+        content: Raw attachment bytes fetched from the Graph API
+        name: Attachment filename (sanitized for the S3 key)
+        content_type: MIME type to serve the object with
+
+    Returns:
+        Pre-signed GET URL valid for DOWNLOAD_URL_TTL_SECONDS
+
+    Raises:
+        AttachmentStagingError: If the staging bucket is not configured
+    """
+    bucket = os.getenv("ATTACHMENT_STAGING_BUCKET")
+    if not bucket:
+        raise AttachmentStagingError(
+            "ATTACHMENT_STAGING_BUCKET is not configured — cannot deliver "
+            "attachments larger than the direct-response limit"
+        )
+
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", name or "")[-128:] or "attachment"
+    key = f"staged-attachments/{uuid.uuid4().hex}/{safe_name}"
+
+    # SigV4 explicitly — boto3's default presigned URLs are legacy SigV2,
+    # which newer buckets/regions reject.
+    s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=content,
+        ContentType=content_type or "application/octet-stream",
+    )
+    url = s3.generate_presigned_url(
+        ClientMethod="get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=DOWNLOAD_URL_TTL_SECONDS,
+    )
+    logger.info("Staged attachment %s (%d bytes) to s3://%s/%s", safe_name, len(content), bucket, key)
+    return url

--- a/amplify-lambda-assistants-api-office365/integrations/o365/outlook.py
+++ b/amplify-lambda-assistants-api-office365/integrations/o365/outlook.py
@@ -3,6 +3,10 @@ import requests
 from typing import Dict, List, Optional, Union
 from datetime import datetime
 from integrations.oauth import get_ms_graph_session
+from integrations.o365.attachment_staging import (
+    DOWNLOAD_URL_TTL_SECONDS,
+    stage_attachment_for_download,
+)
 from integrations.o365.html_utils import html_to_plain_text, markdown_to_html
 from integrations.o365.admin_config import get_default_timezone_windows
 
@@ -404,10 +408,22 @@ def download_attachment(
                     result["contentBytes"] = attachment_metadata.get("contentBytes")
                     result["deliveryMethod"] = "metadata_content"
             else:
-                # Large file - return download URL to avoid API Gateway limits
-                result["downloadUrl"] = f"{GRAPH_ENDPOINT}/me/messages/{message_id}/attachments/{attachment_id}/$value"
+                # Large file — the raw Graph $value URL is useless to callers
+                # (it requires OUR Graph token, so it always 401s). Fetch the
+                # bytes server-side and stage in S3; the caller gets a
+                # pre-signed URL that needs no auth.
+                content_url = f"{GRAPH_ENDPOINT}/me/messages/{message_id}/attachments/{attachment_id}/$value"
+                content_response = session.get(content_url)
+                if not content_response.ok:
+                    handle_graph_error(content_response)
+
+                result["downloadUrl"] = stage_attachment_for_download(
+                    content_response.content,
+                    attachment_metadata.get("name"),
+                    attachment_metadata.get("contentType"),
+                )
                 result["deliveryMethod"] = "download_url"
-                result["note"] = f"File too large ({file_size:,} bytes) for direct API response. Use downloadUrl with authentication headers."
+                result["note"] = f"File too large ({file_size:,} bytes) for direct API response. downloadUrl is a pre-signed URL valid for {DOWNLOAD_URL_TTL_SECONDS // 60} minutes — fetch it without auth headers."
                 
             return result
             

--- a/amplify-lambda-assistants-api-office365/integrations/o365/shared_inbox.py
+++ b/amplify-lambda-assistants-api-office365/integrations/o365/shared_inbox.py
@@ -3,6 +3,10 @@ import json
 import requests
 from typing import Dict, List, Optional
 from integrations.oauth import get_ms_graph_session
+from integrations.o365.attachment_staging import (
+    DOWNLOAD_URL_TTL_SECONDS,
+    stage_attachment_for_download,
+)
 from integrations.o365.html_utils import html_to_plain_text
 
 from pycommon.logger import getLogger
@@ -241,9 +245,10 @@ def download_shared_mailbox_attachment(
     Downloads a specific attachment from a message in a shared Exchange mailbox.
 
     For files under 7MB, returns base64-encoded content directly in the response.
-    For larger files, returns a temporary download URL to avoid API Gateway limits
-    (API Gateway has a 10MB response limit; base64 encoding adds ~33% overhead,
-    so 7MB is the safe threshold).
+    For larger files, the content is fetched server-side, staged in S3, and a
+    pre-signed download URL is returned to avoid API Gateway limits (API Gateway
+    has a 10MB response limit; base64 encoding adds ~33% overhead, so 7MB is the
+    safe threshold). The pre-signed URL must be fetched WITHOUT auth headers.
 
     Handles three Graph API attachment types:
     - fileAttachment: Returns base64 contentBytes or a download URL
@@ -310,15 +315,28 @@ def download_shared_mailbox_attachment(
                     result["contentBytes"] = attachment_metadata.get("contentBytes")
                     result["deliveryMethod"] = "metadata_content"
             else:
-                # Large file — caller must fetch using the download URL with auth headers
-                result["downloadUrl"] = (
+                # Large file — the raw Graph $value URL is useless to callers
+                # (it requires OUR Graph token, which they don't have, so it
+                # always 401s). Fetch the bytes server-side and stage them in
+                # S3; the caller gets a pre-signed URL that needs no auth.
+                content_url = (
                     f"{GRAPH_ENDPOINT}/users/{mailbox_email}/messages/{message_id}"
                     f"/attachments/{attachment_id}/$value"
+                )
+                content_response = session.get(content_url, headers=_IMMUTABLE_ID_HEADER)
+                if not content_response.ok:
+                    _handle_graph_error(content_response)
+
+                result["downloadUrl"] = stage_attachment_for_download(
+                    content_response.content,
+                    attachment_metadata.get("name"),
+                    attachment_metadata.get("contentType"),
                 )
                 result["deliveryMethod"] = "download_url"
                 result["note"] = (
                     f"File too large ({file_size:,} bytes) for direct API response. "
-                    f"Use downloadUrl with an Authorization: Bearer header."
+                    f"downloadUrl is a pre-signed URL valid for "
+                    f"{DOWNLOAD_URL_TTL_SECONDS // 60} minutes — fetch it without auth headers."
                 )
 
             return result

--- a/amplify-lambda-assistants-api-office365/serverless.yml
+++ b/amplify-lambda-assistants-api-office365/serverless.yml
@@ -57,6 +57,10 @@ provider:
     
     # Locally Defined Variables
     LAMBDA_API_IAM_POLICY_NAME: ${self:service}-${sls:stage}-iam-policy
+    # Staging area for mailbox attachments too large for a direct API Gateway
+    # response — served back to callers via pre-signed URL (see
+    # integrations/o365/attachment_staging.py). 1-day lifecycle expiration.
+    ATTACHMENT_STAGING_BUCKET: ${self:service}-${sls:stage}-attachments
 
     # Imported Variables from Parameter Store
     ACCOUNTS_DYNAMO_TABLE: ${ssm:${self:custom.ssmBasePath}-lambda/ACCOUNTS_DYNAMO_TABLE}
@@ -126,6 +130,28 @@ resources:
             path: /microsoft/integrations/{proxy+}
             method: POST
 
+    # Short-lived staging for mailbox attachments >7MB (see
+    # integrations/o365/attachment_staging.py). Callers receive a pre-signed
+    # GET URL; the lifecycle rule cleans up staged objects after a day.
+    AttachmentStagingBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:provider.environment.ATTACHMENT_STAGING_BUCKET}
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        LifecycleConfiguration:
+          Rules:
+            - Id: DeleteStagedAttachments
+              Status: Enabled
+              ExpirationInDays: 1
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
+
     LambdaAPIIAMPolicy:
       Type: AWS::IAM::ManagedPolicy
       Properties:
@@ -188,6 +214,13 @@ resources:
                 - ssm:GetParametersByPath
               Resource:
                 - arn:aws:ssm:${self:provider.region}:${aws:accountId}:parameter${self:custom.ssmBasePath}-*   
+
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+                - s3:GetObject
+              Resource:
+                - "arn:aws:s3:::${self:provider.environment.ATTACHMENT_STAGING_BUCKET}/*"
 
             - Effect: Allow
               Action:

--- a/amplify-lambda-assistants-api-office365/service/core.py
+++ b/amplify-lambda-assistants-api-office365/service/core.py
@@ -1053,7 +1053,7 @@ def get_attachments_handler(current_user, data):
     path="/microsoft/integrations/download_attachment",
     tags=["default", "integration", "microsoft_outlook", "microsoft_outlook_read"],
     name="microsoftDownloadAttachment",
-    description="Downloads a specific attachment from a message. Files under 7MB return base64 content directly. Larger files return download URLs to avoid API Gateway limits.",
+    description="Downloads a specific attachment from a message. Files under 7MB return base64 content directly. Larger files return a pre-signed download URL (fetch it without auth headers) to avoid API Gateway limits.",
     parameters={
         "type": "object",
         "properties": {
@@ -4046,7 +4046,7 @@ def get_shared_mailbox_attachments_handler(current_user, data):
     path="/microsoft/integrations/download_shared_mailbox_attachment",
     tags=["default", "integration", "microsoft_exchange", "microsoft_exchange_read"],
     name="microsoftDownloadSharedMailboxAttachment",
-    description="Downloads a specific attachment from a message in a shared Exchange mailbox. Files under 7MB return base64-encoded content directly. Larger files return a download URL to avoid API Gateway limits.",
+    description="Downloads a specific attachment from a message in a shared Exchange mailbox. Files under 7MB return base64-encoded content directly. Larger files return a pre-signed download URL (fetch it without auth headers) to avoid API Gateway limits.",
     parameters={
         "type": "object",
         "properties": {


### PR DESCRIPTION
To test it: 

cd /Volumes/Projects/amplify-genai-backend/amplify-lambda-assistants-api-office365 && sls deploy --stage dev

cd /Volumes/Projects/majk-invoice-validator && npx tsx file.ts


file.ts
--

// End-to-end test of the >7MB attachment fix, using the real client code path.
import fs from 'fs';

// Load .env.local (KEY=VALUE lines only)
for (const line of fs.readFileSync('/Volumes/Projects/majk-invoice-validator/.env.local', 'utf8').split('\n')) {
    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
    if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2];
}

import { listMessagesWithAttachments, listAttachments, downloadAttachment } from '/Volumes/Projects/majk-invoice-validator/lib/amplify-mailbox';

const SEVEN_MB = 7 * 1024 * 1024;

async function main() {
    const messages = await listMessagesWithAttachments({ top: 25 });
    console.log(`${messages.length} messages with attachments`);

    for (const msg of messages) {
        const atts = await listAttachments(msg.id);
        const big = atts.find(a => (a.size ?? 0) > SEVEN_MB);
        if (!big) continue;

        console.log(`Testing: "${big.name}" (${((big.size ?? 0) / 1e6).toFixed(1)} MB) from "${msg.subject}"`);
        const result = await downloadAttachment(msg.id, big.id);

        if (result.ok) {
            console.log(`\nSUCCESS: downloaded ${result.buffer.length.toLocaleString()} bytes (${result.contentType})`);
            const head = result.buffer.subarray(0, 5).toString('latin1');
            console.log(head.startsWith('%PDF-') ? 'Content check: valid PDF header' : `Content head: ${JSON.stringify(head)}`);
        } else {
            console.error(`\nFAILED: ${JSON.stringify(result)}`);
            process.exit(1);
        }
        return;
    }
    console.log('No attachment >7MB found in the first 25 messages — nothing to test.');
}

main().catch(err => {
    console.error('FAILED:', err.response?.status, err.response?.data ?? err.message);
    process.exit(1);
});
