### PR TITLE
Fix: Add filename reference labels to LLM prompts

### DIFF
--- a/amplify-lambda-js/azure/openai.js
+++ b/amplify-lambda-js/azure/openai.js
@@ -648,8 +648,14 @@ async function includeImageSources(dataSources, messages, model, responseStream,
       });
     const retrievedImages = [];
 
+    // Extract filenames for reference labels - prefer ds.name (original filename) over S3 path
+    const imageFilenames = dataSources.map((ds, idx) => {
+        const filename = ds.name || ds.id.split('/').pop() || `image_${idx + 1}`;
+        return filename;
+    });
+
     let imageMessageContent = [];
-    
+
     for (let i = 0; i < dataSources.length; i++) {
         const ds = dataSources[i];
         const encoded_image = await getImageBase64Content(ds);
@@ -661,27 +667,33 @@ async function includeImageSources(dataSources, messages, model, responseStream,
                     "image_url": `data:${ds.type};base64,${encoded_image}`
                 });
             } else {
-                imageMessageContent.push( 
+                imageMessageContent.push(
                     { "type": "image_url",
                       "image_url": {"url": `data:${ds.type};base64,${encoded_image}`, "detail": "high"}
-                    } 
+                    }
                 );
             }
         }
     }
-    
+
     if (retrievedImages.length > 0) {
         sendStateEventToStream(responseStream, {
             sources: { images: { sources: retrievedImages} }
           });
     }
 
+    // Build image reference labels to help model map filenames to images
+    const imageReferenceLabels = imageFilenames
+        .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
+        .join('\n');
+    const imageReferenceInstruction = `Image Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.\n\n`;
+
     // message must be a user message
     const textType = isNonStandardOpenAI ? "input_text" : "text";
     messages[msgLen]['content'] = [{ "type": textType,
-                                     "text": additionalImageInstruction
-                                    }, 
-                                    ...imageMessageContent, 
+                                     "text": imageReferenceInstruction + additionalImageInstruction
+                                    },
+                                    ...imageMessageContent,
                                     { "type": textType,
                                         "text": messages[msgLen]['content']
                                     }

--- a/amplify-lambda-js/azure/openai.js
+++ b/amplify-lambda-js/azure/openai.js
@@ -682,16 +682,11 @@ async function includeImageSources(dataSources, messages, model, responseStream,
           });
     }
 
-    // Build image reference labels to help model map filenames to images
-    const imageReferenceLabels = imageFilenames
-        .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
-        .join('\n');
-    const imageReferenceInstruction = `Image Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.\n\n`;
-
+ 
     // message must be a user message
     const textType = isNonStandardOpenAI ? "input_text" : "text";
     messages[msgLen]['content'] = [{ "type": textType,
-                                     "text": imageReferenceInstruction + additionalImageInstruction
+                                     "text": additionalImageInstruction(imageFilenames)
                                     },
                                     ...imageMessageContent,
                                     { "type": textType,

--- a/amplify-lambda-js/bedrock/bedrock.js
+++ b/amplify-lambda-js/bedrock/bedrock.js
@@ -498,6 +498,12 @@ async function sanitizeMessages(messages, imageSources, model, responseStream) {
 async function includeImageSources(dataSources, messages, responseStream) {
     if (!dataSources || dataSources.length === 0) return messages;
 
+    // Extract filenames for reference labels - prefer ds.name (original filename) over S3 path
+    const imageFilenames = dataSources.map((ds, idx) => {
+        const filename = ds.name || ds.id.split('/').pop() || `image_${idx + 1}`;
+        return filename;
+    });
+
     // Process all images in parallel for faster execution
     const imagePromises = dataSources.map(async (ds) => {
         try {
@@ -507,7 +513,7 @@ async function includeImageSources(dataSources, messages, responseStream) {
                     ds: {...ds, contentKey: extractKey(ds.id)},
                     imageData: {
                         "image": {
-                            "format": ds.type.split('/')[1], 
+                            "format": ds.type.split('/')[1],
                             "source": {
                                 "bytes": Uint8Array.from(atob(encoded_image), char => char.charCodeAt(0))
                             }
@@ -520,12 +526,12 @@ async function includeImageSources(dataSources, messages, responseStream) {
         }
         return null;
     });
-    
+
     const results = await Promise.all(imagePromises);
     const retrievedImages = [];
     let imageMessageContent = [[]];
     let listIdx = 0;
-    
+
     // Process results
     for (const result of results) {
         if (result) {
@@ -547,7 +553,14 @@ async function includeImageSources(dataSources, messages, responseStream) {
 
     const msgLen = messages.length - 1;
     let content = messages[msgLen]['content'];
-    content.push({ "text": additionalImageInstruction});
+
+    // Build image reference labels to help model map filenames to images
+    const imageReferenceLabels = imageFilenames
+        .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
+        .join('\n');
+    const imageReferenceInstruction = `\n\nImage Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.`;
+
+    content.push({ "text": imageReferenceInstruction + additionalImageInstruction});
     content = [...content, ...imageMessageContent[0]];
     messages[msgLen]['content'] = content;
     if (listIdx > 0) {

--- a/amplify-lambda-js/bedrock/bedrock.js
+++ b/amplify-lambda-js/bedrock/bedrock.js
@@ -554,13 +554,8 @@ async function includeImageSources(dataSources, messages, responseStream) {
     const msgLen = messages.length - 1;
     let content = messages[msgLen]['content'];
 
-    // Build image reference labels to help model map filenames to images
-    const imageReferenceLabels = imageFilenames
-        .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
-        .join('\n');
-    const imageReferenceInstruction = `\n\nImage Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.`;
 
-    content.push({ "text": imageReferenceInstruction + additionalImageInstruction});
+    content.push({ "text": additionalImageInstruction(imageFilenames)});
     content = [...content, ...imageMessageContent[0]];
     messages[msgLen]['content'] = content;
     if (listIdx > 0) {

--- a/amplify-lambda-js/datasource/datasources.js
+++ b/amplify-lambda-js/datasource/datasources.js
@@ -17,7 +17,14 @@ const logger = getLogger("datasources");
 const client = new S3Client();
 const dynamodbClient = new DynamoDBClient();
 
-export const additionalImageInstruction = "\n\n Additional Image Instructions:\n If given an encode image, describe the image in vivid detail, capturing every element, including the subjects, colors, textures, and emotions. Provide enough information so that someone can visualize the image perfectly without seeing it, using precise and rich language. This should be its own block of text."
+export const additionalImageInstruction = (imageFileNames) => {
+    // Build image reference labels to help model map filenames to images
+    const imageReferenceLabels = imageFileNames
+        .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
+        .join('\n');
+
+    return `Image Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.\n\n Additional Image Instructions:\n If given an encode image, describe the image in vivid detail, capturing every element, including the subjects, colors, textures, and emotions. Provide enough information so that someone can visualize the image perfectly without seeing it, using precise and rich language. This should be its own block of text.`
+}
 
 const dataSourcesQueryEndpoint = process.env.API_BASE_URL + "/files/query";
 const hashFilesTableName = process.env.HASH_FILES_DYNAMO_TABLE;
@@ -76,6 +83,7 @@ export const getFileText = async (key) => {
 export const doesNotSupportImagesInstructions = (modelName) => {
     return `\n\n At the end of your response, please let the user know the model ${modelName} does not support images. Advise them to try another model.`;
 }
+
 
 export const getImageBase64Content = async (dataSource) => {
     const bucket = process.env.S3_IMAGE_INPUT_BUCKET_NAME;

--- a/amplify-lambda-js/gemini/gemini.js
+++ b/amplify-lambda-js/gemini/gemini.js
@@ -438,6 +438,12 @@ async function includeImageSources(imageSources, messages, model, responseStream
     }
 
     try {
+        // Extract filenames for reference labels - prefer source.name (original filename) over S3 path
+        const imageFilenames = imageSources.map((ds, idx) => {
+            const filename = ds.name || ds.id.split('/').pop() || `image_${idx + 1}`;
+            return filename;
+        });
+
         // Process all images
         const imagePromises = imageSources.map(async (source) => {
             const base64Content = await getImageBase64Content(source);
@@ -459,22 +465,46 @@ async function includeImageSources(imageSources, messages, model, responseStream
         if (firstUserMsgIndex !== -1) {
             const userMsg = messages[firstUserMsgIndex];
 
+            // Build image reference labels to help model map filenames to images
+            const imageReferenceLabels = imageFilenames
+                .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
+                .join('\n');
+            const imageReferenceInstruction = `Image Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.\n\n`;
+
             // Convert to the OpenAI format for multimodal content
             if (typeof userMsg.content === 'string') {
                 // Convert string content to array format
                 messages[firstUserMsgIndex] = {
                     ...userMsg,
                     content: [
-                        { type: "text", text: userMsg.content },
+                        { type: "text", text: imageReferenceInstruction + userMsg.content },
                         ...imageContents
                     ]
                 };
             } else if (Array.isArray(userMsg.content)) {
-                // Add to existing array content
-                messages[firstUserMsgIndex] = {
-                    ...userMsg,
-                    content: [...userMsg.content, ...imageContents]
-                };
+                // Prepend image reference to first text content, or add as new text content
+                const hasTextContent = userMsg.content.some(c => c.type === 'text');
+                if (hasTextContent) {
+                    // Prepend to existing text content
+                    messages[firstUserMsgIndex] = {
+                        ...userMsg,
+                        content: userMsg.content.map(c =>
+                            c.type === 'text' && !c.text.includes('Image Reference Labels')
+                                ? { ...c, text: imageReferenceInstruction + c.text }
+                                : c
+                        )
+                    };
+                } else {
+                    // Add as new text content if no text exists
+                    messages[firstUserMsgIndex] = {
+                        ...userMsg,
+                        content: [
+                            { type: "text", text: imageReferenceInstruction },
+                            ...userMsg.content,
+                            ...imageContents
+                        ]
+                    };
+                }
             }
         }
 

--- a/amplify-lambda-js/gemini/gemini.js
+++ b/amplify-lambda-js/gemini/gemini.js
@@ -465,12 +465,8 @@ async function includeImageSources(imageSources, messages, model, responseStream
         if (firstUserMsgIndex !== -1) {
             const userMsg = messages[firstUserMsgIndex];
 
-            // Build image reference labels to help model map filenames to images
-            const imageReferenceLabels = imageFilenames
-                .map((filename, idx) => `- Image #${idx + 1}: ${filename}`)
-                .join('\n');
-            const imageReferenceInstruction = `Image Reference Labels:\n${imageReferenceLabels}\n\nWhen describing or referencing images, use the image numbers (#1, #2, etc.) and filenames shown above.\n\n`;
-
+     
+            const imageReferenceInstruction = additionalImageInstruction(imageFilenames);
             // Convert to the OpenAI format for multimodal content
             if (typeof userMsg.content === 'string') {
                 // Convert string content to array format
@@ -511,7 +507,6 @@ async function includeImageSources(imageSources, messages, model, responseStream
         sendStateEventToStream(responseStream, {
             sources: { images: { sources: imageSources.map(ds => ({ ...ds, contentKey: extractKey(ds.id) })) } }
         });
-        sendStateEventToStream(responseStream, additionalImageInstruction);
         return messages;
     } catch (error) {
         console.error("Error processing images:", error);
@@ -572,7 +567,6 @@ async function includeVideoSources(videoSources, messages, model, responseStream
         sendStateEventToStream(responseStream, {
             sources: { videos: { sources: videoSources.map(ds => ({ ...ds, contentKey: extractKey(ds.id) })) } }
         });
-        sendStateEventToStream(responseStream, additionalImageInstruction);
         return messages;
     } catch (error) {
         console.error("Error processing videos:", error);


### PR DESCRIPTION
Changes
- bedrock/bedrock.js: Extract filenames from upload metadata and prepend reference labels to prompts
- azure/openai.js: Same filename reference label enhancement for Azure OpenAI
- gemini/gemini.js: Same filename reference label enhancement for Gemini models

